### PR TITLE
OBKN-658 OrderDetails returns to first picklist item on every pick

### DIFF
--- a/src/screens/OrderDetails/index.tsx
+++ b/src/screens/OrderDetails/index.tsx
@@ -42,7 +42,9 @@ const OrderDetails: React.FC<Props> = (props) => {
         return;
       }
 
-      if (getInitiallyDisplayedPickItemIndex(data?.picklistItems) === -1) {
+      const initialPicklistItemIndex = getInitiallyDisplayedPickItemIndex(data?.picklistItems);
+
+      if (initialPicklistItemIndex === -1) {
         Alert.alert(
           'All items are picked',
           'What do you want to do now?',

--- a/src/screens/PickList/index.tsx
+++ b/src/screens/PickList/index.tsx
@@ -163,7 +163,7 @@ const PickOrderItem = (props: any) => {
   return (
     <View style={styles.screenContainer}>
         <Carousel
-          key={3}
+          key={props.selectedPinkItemIndex}
           sliderWidth={device.windowWidth}
           sliderHeight={device.windowHeight}
           activeSlideAlignment="start"
@@ -171,6 +171,7 @@ const PickOrderItem = (props: any) => {
           data={picklistItems}
           firstItem={props.selectedPinkItemIndex ? props.selectedPinkItemIndex : 0}
           scrollEnabled={true}
+          useScrollView={true}
           pointerEvents={'none'}
           lockScrollWhileSnapping
           renderItem={({item, index}: ListRenderItemInfo<PicklistItem>) => {


### PR DESCRIPTION
The ticket describes something else than Justin's videos, but that's okay and I'll describe why:

- when Justin was recording those movies, he was using version before the refactor of OrderDetails component and that was a big issue connected to `Carousel` and `FlatList`: a nice discussion about this topic is here: [link](https://github.com/meliorence/react-native-snap-carousel/issues/63)
To fix that (it seemed like for all people reporting that issue, the problem happened when their data was > 6 length) I just had to add `useScrollview={true}`.

BUT it was when using old, before refactor OrderDetails component. On new one it's true, that it always returned to first item, because `initialPicklistItemIndex` was passed to props wrongly and it was always 0 when console.loged inside Carousel (it was setting the intialPicklsitItemIndex state as the previous one, so in general it was setting that as the initial value, so 0). 
Then another problem saw the light of the day - when I fixed `initialPicklistItemIndex` it turned out, that the `Carousel` 'doesn't see' that the state (initialPiclistItemIndex) updated, so in the beginning it was rendered a few times with 0 passed as props (before the `getOrderDetails()` function ended its work) and then it was passing the correct value, for example: 8 (but those renders were just a characteristic of React and there is nothing wrong about that - the wrong part was that the `Carousel` didn't react that `firstItem` was updated from 0 to 8 etc.).
I was wondering why and thought that maybe `Carousel` just doesn't re-render after the `firstItem` changes and yeah, the `key` was set (don't know why) as `3`. I think it made `Carousel` not re-rendering when the `firstItem` changed from props.
After changing `key` to actual value of `initialPicklistItemIndex` the problem doesn't happen anymore - the `Carousel` updates the `firstItem` propely (it just re-renders)