### PR TITLE
OB-3242 add a redux-persister, add ui settings

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,17 +1,29 @@
+import { DSN_KEY } from '@env';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Sentry from '@sentry/react-native';
 import React, { Component } from 'react';
+import { StatusBar } from 'react-native';
 import { Provider } from 'react-redux';
-import { createStore, applyMiddleware } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import { persistReducer, persistStore } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
+
+import Main from './src/Main';
 import rootReducer from './src/redux/reducers';
 import watchers from './src/redux/sagas';
-import Main from './src/Main';
-import { StatusBar } from 'react-native';
-import { colors } from './src/constants';
-import * as Sentry from '@sentry/react-native';
-import { DSN_KEY } from '@env';
+import { PersistGate } from 'redux-persist/integration/react';
+
+const persistConfig = {
+  key: 'root',
+  storage: AsyncStorage,
+  whitelist: ['settingsReducer']
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 const saga = createSagaMiddleware();
-export const store = createStore(rootReducer, applyMiddleware(saga));
+export const store = createStore(persistedReducer, applyMiddleware(saga));
+export const persistor = persistStore(store);
 saga.run(watchers);
 
 Sentry.init({
@@ -21,8 +33,10 @@ export class App extends Component {
   render() {
     return (
       <Provider store={store}>
-        <StatusBar hidden={false} barStyle="light-content" />
-        <Main />
+        <PersistGate loading={null} persistor={persistor}>
+          <StatusBar hidden={false} barStyle="light-content" />
+          <Main />
+        </PersistGate>
       </Provider>
     );
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-redux": "~7.2.5",
     "redux": "^4.1.1",
     "redux-logger": "~3.0.6",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3"
   },
   "devDependencies": {

--- a/src/components/CustomDrawerContent/CustomDrawerContent.tsx
+++ b/src/components/CustomDrawerContent/CustomDrawerContent.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { View } from 'react-native';
 import { Button, Caption, Paragraph } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
+
+import * as NavigationService from '../../NavigationService';
 import { logout } from '../../redux/actions/auth';
 import { RootState } from '../../redux/reducers';
 import Theme from '../../utils/Theme';
@@ -32,7 +34,22 @@ const CustomDrawerContent = (props: DrawerContentComponentProps) => {
       </View>
 
       <View style={styles.logoutSection}>
-        <Button icon="logout" mode="contained" color={Theme.colors.primary} onPress={handleLogout}>
+        <Button
+          icon="cog"
+          mode="outlined"
+          onPress={() => {
+            NavigationService.navigate('Settings');
+          }}
+        >
+          Settings
+        </Button>
+        <Button
+          icon="logout"
+          mode="contained"
+          color={Theme.colors.primary}
+          style={styles.logoutButton}
+          onPress={handleLogout}
+        >
           Logout
         </Button>
       </View>

--- a/src/components/CustomDrawerContent/styles.ts
+++ b/src/components/CustomDrawerContent/styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from 'react-native';
+import Theme from '../../utils/Theme';
 
 export const styles = StyleSheet.create({
   userInfoSection: {
@@ -26,8 +27,10 @@ export const styles = StyleSheet.create({
     fontWeight: 'bold'
   },
   logoutSection: {
-    padding: 20,
-    borderTopWidth: 0.5,
+    padding: Theme.spacing.large,
     borderTopColor: '#ccc'
+  },
+  logoutButton: {
+    marginTop: Theme.spacing.small
   }
 });

--- a/src/redux/actions/settings.ts
+++ b/src/redux/actions/settings.ts
@@ -1,0 +1,19 @@
+export const GROUP_LOCATION_ENTIRES = 'GROUP_LOCATION_ENTIRES';
+
+type SetGroupLocationEntriesAction = {
+  type: typeof GROUP_LOCATION_ENTIRES;
+  payload: {
+    group: boolean;
+  };
+};
+
+// Create a union type for all action types in this file.
+// e.g., export type SettingsActionTypes = SetGroupLocationEntriesAction | SetThemeAction;
+export type SettingsActionTypes = SetGroupLocationEntriesAction;
+
+export const setGroupLocationEntries = (group: boolean): SetGroupLocationEntriesAction => {
+  return {
+    type: GROUP_LOCATION_ENTIRES,
+    payload: { group }
+  };
+};

--- a/src/redux/reducers/index.ts
+++ b/src/redux/reducers/index.ts
@@ -1,16 +1,19 @@
 import { combineReducers } from 'redux';
+import locationsReducer from './locationsReducer';
 import mainReducer from './mainReducer';
 import productsReducer from './productsReducer';
 import putawayReducer from './putawayReducer';
-import locationsReducer from './locationsReducer';
+import settingsReducer from './settingsReducer';
 
 const rootReducer = combineReducers({
   mainReducer,
   productsReducer,
   putawayReducer,
-  locationsReducer
+  locationsReducer,
+  settingsReducer
 });
 
+// eslint-disable-next-line no-undef
 export type RootState = ReturnType<typeof rootReducer>;
 
 export default rootReducer;

--- a/src/redux/reducers/settingsReducer.ts
+++ b/src/redux/reducers/settingsReducer.ts
@@ -1,0 +1,25 @@
+import { GROUP_LOCATION_ENTIRES, SettingsActionTypes } from '../actions/settings';
+
+type SettingsState = {
+  groupLocationEntries: boolean;
+};
+
+const initialState: SettingsState = {
+  groupLocationEntries: false
+};
+
+function settingsReducer(state = initialState, action: SettingsActionTypes): SettingsState {
+  switch (action.type) {
+    case GROUP_LOCATION_ENTIRES: {
+      return {
+        ...state,
+        groupLocationEntries: action.payload.group
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+}
+
+export default settingsReducer;

--- a/src/screens/ChooseCurrentLocation/index.tsx
+++ b/src/screens/ChooseCurrentLocation/index.tsx
@@ -186,13 +186,11 @@ class ChooseCurrentLocation extends React.Component<Props, State> {
       );
     }
 
-    const sortedAvailableLocations = this.getSortedOrgNameAndLocationsDictionary(availableLocations);
-
     return (
       <View>
         <ScrollView style={styles.scrollView}>
           {groupLocationEntries
-            ? this.renderGroupedLocations(sortedAvailableLocations)
+            ? this.renderGroupedLocations(this.getSortedOrgNameAndLocationsDictionary(availableLocations))
             : this.renderAllLocations(availableLocations)}
         </ScrollView>
       </View>

--- a/src/screens/ChooseCurrentLocation/index.tsx
+++ b/src/screens/ChooseCurrentLocation/index.tsx
@@ -1,7 +1,7 @@
-import _ from 'lodash';
+import _, { Dictionary } from 'lodash';
 import React from 'react';
 import { ScrollView, View } from 'react-native';
-import { Card, Text } from 'react-native-paper';
+import { Card, List, Text } from 'react-native-paper';
 import { connect } from 'react-redux';
 
 import GarageIcon from '../../assets/images/icon_garage.svg';
@@ -10,12 +10,16 @@ import showPopup from '../../components/Popup';
 import Location from '../../data/location/Location';
 import { getLocationsAction, setCurrentLocationAction } from '../../redux/actions/locations';
 import { hideScreenLoading, showScreenLoading } from '../../redux/actions/main';
+import { RootState } from '../../redux/reducers';
+import Theme from '../../utils/Theme';
 import styles from './styles';
 
+const NO_ORGANIZATION_NAME = 'No organization';
 const NO_LOCATION_GROUP_NAME = 'NO_LOCATION_GROUP_PROVIDED';
 
 export interface OwnProps {
   navigation: any;
+  groupLocationEntries?: boolean;
 }
 
 interface DispatchProps {
@@ -94,8 +98,82 @@ class ChooseCurrentLocation extends React.Component<Props, State> {
     });
   };
 
+  getSortedOrgNameAndLocationsDictionary = (locations: Location[]): Dictionary<Location[]> => {
+    // Group locations by organization name or 'No organization' if no name is provided
+    const orgNameAndLocationsDictionary = _.groupBy(
+      locations,
+      (location: Location) => location.organizationName || NO_ORGANIZATION_NAME
+    );
+
+    // Sort the organization names alphabetically, with 'No organization' at the end
+    const sortedOrgNames = _.orderBy(
+      Object.keys(orgNameAndLocationsDictionary),
+      [(orgName) => (orgName === NO_ORGANIZATION_NAME ? Infinity : orgName)],
+      ['asc']
+    );
+
+    // Rebuild the dictionary with sorted keys
+    return _.reduce(
+      sortedOrgNames,
+      (acc: Dictionary<Location[]>, orgName: string) => {
+        const sortedLocations = _.orderBy(orgNameAndLocationsDictionary[orgName], ['name'], ['asc']);
+        acc[orgName] = sortedLocations;
+        return acc;
+      },
+      {}
+    );
+  };
+
+  renderGroupedLocations = (locations: Dictionary<Location[]>) => (
+    <List.AccordionGroup>
+      {_.map(_.keys(locations), (orgName: string) => {
+        return (
+          <List.Accordion
+            title={orgName}
+            description={`${locations[orgName].length} Location(s)`}
+            id={`orgName_${orgName}`}
+            left={(props) => <List.Icon {...props} color={Theme.colors.primary} icon="office-building" />}
+            key={`orgName_${orgName}`}
+            style={{ backgroundColor: Theme.colors.surface, borderRadius: Theme.roundness }}
+          >
+            {_.map(locations[orgName], (location) => {
+              return (
+                <List.Item
+                  title={location.name}
+                  description={location.locationGroup?.name ?? NO_LOCATION_GROUP_NAME}
+                  key={`orgName_${orgName}_locationName_${location.name}`}
+                  hasTVPreferredFocus={false}
+                  tvParallaxProperties={undefined}
+                  style={{ backgroundColor: Theme.colors.surface, borderRadius: Theme.roundness }}
+                  onPress={() => this.setCurrentLocation(location)}
+                />
+              );
+            })}
+          </List.Accordion>
+        );
+      })}
+    </List.AccordionGroup>
+  );
+
+  renderAllLocations = (locations: Location[]) =>
+    locations.map((location) => (
+      <Card key={location.id} style={styles.cardContainer} onPress={() => this.setCurrentLocation(location)}>
+        <Card.Content style={styles.cardContent}>
+          <View style={styles.contentContainer}>
+            <GarageIcon width={48} height={48} />
+
+            <View style={styles.textContainer}>
+              <Text style={styles.cardTitle}>{location.name}</Text>
+              <Text style={styles.cardSubtitle}>{location.locationGroup?.name || NO_LOCATION_GROUP_NAME}</Text>
+            </View>
+          </View>
+        </Card.Content>
+      </Card>
+    ));
+
   render() {
     const { availableLocations } = this.state;
+    const { groupLocationEntries } = this.props;
 
     if (!availableLocations || availableLocations.length === 0) {
       return (
@@ -108,28 +186,23 @@ class ChooseCurrentLocation extends React.Component<Props, State> {
       );
     }
 
+    const sortedAvailableLocations = this.getSortedOrgNameAndLocationsDictionary(availableLocations);
+
     return (
       <View>
         <ScrollView style={styles.scrollView}>
-          {availableLocations.map((location) => (
-            <Card key={location.id} style={styles.cardContainer} onPress={() => this.setCurrentLocation(location)}>
-              <Card.Content style={styles.cardContent}>
-                <View style={styles.contentContainer}>
-                  <GarageIcon width={48} height={48} />
-
-                  <View style={styles.textContainer}>
-                    <Text style={styles.cardTitle}>{location.name}</Text>
-                    <Text style={styles.cardSubtitle}>{location.locationGroup?.name || NO_LOCATION_GROUP_NAME}</Text>
-                  </View>
-                </View>
-              </Card.Content>
-            </Card>
-          ))}
+          {groupLocationEntries
+            ? this.renderGroupedLocations(sortedAvailableLocations)
+            : this.renderAllLocations(availableLocations)}
         </ScrollView>
       </View>
     );
   }
 }
+
+const mapStateToProps = (state: RootState) => ({
+  groupLocationEntries: state.settingsReducer.groupLocationEntries
+});
 
 const mapDispatchToProps: DispatchProps = {
   getLocationsAction,
@@ -138,4 +211,4 @@ const mapDispatchToProps: DispatchProps = {
   hideScreenLoading
 };
 
-export default connect(null, mapDispatchToProps)(ChooseCurrentLocation);
+export default connect(mapStateToProps, mapDispatchToProps)(ChooseCurrentLocation);

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -1,44 +1,81 @@
-import React, { useEffect, useState } from 'react';
-import { View, Text } from 'react-native';
-import { TextInput } from 'react-native-paper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { environment } from '../../utils/Environment';
-import * as NavigationService from '../../NavigationService';
-import ApiClient from '../../utils/ApiClient';
+import React, { useEffect, useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { Caption, Card, Paragraph, Switch, TextInput } from 'react-native-paper';
+import { useDispatch, useSelector } from 'react-redux';
+
 import Button from '../../components/Button';
+import * as NavigationService from '../../NavigationService';
+import { setGroupLocationEntries } from '../../redux/actions/settings';
+import { RootState } from '../../redux/reducers';
+import ApiClient from '../../utils/ApiClient';
+import { environment } from '../../utils/Environment';
+import Theme from '../../utils/Theme';
 import styles from './styles';
 
 const Settings = () => {
-  const [value, setValue] = useState('');
+  const dispatch = useDispatch();
+
+  const [serverUrl, setServerUrl] = useState('');
+
+  const groupLocationEntries = useSelector((state: RootState) => state.settingsReducer.groupLocationEntries);
 
   useEffect(() => {
     AsyncStorage.getItem('API_URL').then((url) => {
-      setValue(url || environment.API_BASE_URL);
+      setServerUrl(url || environment.API_BASE_URL);
     });
   }, []);
 
-  const handlePress = () => {
-    ApiClient.setBaseUrl(value);
-    AsyncStorage.setItem('API_URL', value).then(() => {
-      NavigationService.navigate('Login');
+  const handleServerUrlSave = () => {
+    ApiClient.setBaseUrl(serverUrl);
+    AsyncStorage.setItem('API_URL', serverUrl).then(() => {
+      NavigationService.goBack();
     });
   };
 
+  const handleToggleGroupEntries = () => {
+    dispatch(setGroupLocationEntries(!groupLocationEntries));
+  };
+
   return (
-    <View style={styles.card}>
-      <Text>Here, you can enter the server URL, which will serve as the backend for the mobile app.</Text>
-      <TextInput
-        style={styles.input}
-        mode="outlined"
-        label="Server URL"
-        placeholder="http://localhost:8080/"
-        value={value}
-        onChangeText={(text) => {
-          setValue(text);
-        }}
-      />
-      <Button size="100%" title="Confirm" onPress={handlePress} />
-    </View>
+    <ScrollView style={styles.container}>
+      <Card style={styles.card}>
+        <Card.Title title="Server Connection" />
+        <Card.Content>
+          <Paragraph style={styles.paragraph}>
+            Set the server URL that will serve as the backend for the mobile application.
+          </Paragraph>
+          <TextInput
+            style={styles.input}
+            mode="outlined"
+            label="Server URL"
+            placeholder="http://localhost:8080/"
+            value={serverUrl}
+            onChangeText={(text) => {
+              setServerUrl(text);
+            }}
+          />
+          <Button mode="contained" size="100%" title="Save and Apply" onPress={handleServerUrlSave} />
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.card}>
+        <Card.Title title="UI Preferences" />
+        <Card.Content>
+          <View style={styles.settingRow}>
+            <View style={styles.settingTextContainer}>
+              <Paragraph>Group Location Entries</Paragraph>
+              <Caption>Displays locations from the same organization in a collapsible list.</Caption>
+            </View>
+            <Switch
+              value={groupLocationEntries}
+              color={Theme.colors.primary}
+              onValueChange={handleToggleGroupEntries}
+            />
+          </View>
+        </Card.Content>
+      </Card>
+    </ScrollView>
   );
 };
 

--- a/src/screens/Settings/styles.ts
+++ b/src/screens/Settings/styles.ts
@@ -1,15 +1,30 @@
 import { StyleSheet } from 'react-native';
+import Theme from '../../utils/Theme';
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: Theme.spacing.small
+  },
   card: {
-    padding: 16,
-    margin: 8,
-    borderRadius: 8,
-    backgroundColor: 'white',
-    elevation: 2
+    margin: Theme.spacing.small,
+    elevation: Theme.spacing.small / 2
+  },
+  paragraph: {
+    marginBottom: Theme.spacing.large
   },
   input: {
-    marginVertical: 16
+    marginBottom: Theme.spacing.large
+  },
+  settingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: Theme.spacing.small
+  },
+  settingTextContainer: {
+    flex: 1,
+    marginRight: Theme.spacing.large
   }
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8186,6 +8186,11 @@ redux-logger@~3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-saga@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.3.0.tgz#a59ada7c28010189355356b99738c9fcb7ade30e"


### PR DESCRIPTION
[OB-3242](https://openboxes.atlassian.net/browse/OB-3242)

Changes:
- Add a `redux-persister`. Create a settings reducer that is persisted.
- Allow user to determine whether the locations should be grouped or not.
![image](https://github.com/user-attachments/assets/5bc952a5-9326-4450-8a49-3b71c812268d)
- Added a settings button to the drawer.
![image](https://github.com/user-attachments/assets/fbe3efc3-5fc7-4505-8ef6-7d805b8332f4)
