### PR TITLE
Extend Bitrise CI to build iOS app

### DIFF
--- a/.bitrise/bitrise.yml
+++ b/.bitrise/bitrise.yml
@@ -7,31 +7,35 @@ trigger_map:
 - push_branch: master
   workflow: app_distribution_to_testers
 - push_branch: develop
-  workflow: primary
+  workflow: android-only
 - pull_request_target_branch: develop
-  workflow: primary
+  workflow: android-only
 - pull_request_source_branch: "*"
-  workflow: primary
+  workflow: android-only
 
 _dependency_versions:
   # https://github.com/android/ndk/wiki/Unsupported-Downloads#r21e
   android_ndk_version: &android_ndk_version 21.4.7075529
+  # On stacks that support Xcode 16+, Bitrise's install-missing-android-tools
+  # step ends up calling an sdkmanager release that requires Java 17+.
+  java_version_ndk: &java_version_ndk 17
+  # But for everything else we want to keep using Java 11
+  java_version: &java_version 11
   node_version: &node_version 14.21.3
   # We use RN 0.66; use this table to find the correct version of react-native-cli
   # https://github.com/react-native-community/cli?tab=readme-ov-file#compatibility
   react_native_cli_version: &react_native_cli_version 6.4.0
 
 step_bundles:
-  setup_steps:
+  setup-steps:
     description: |-
-      Check out code, install dependencies, and prepare the environment.
+      Check out code, install common dependencies, and prepare the environment.
     steps:
       - activate-ssh-key@4:
           run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
       - git-clone@8:
           is_always_run: true
       - script@1:
-          title: Script - create .env file
           inputs:
           - content: |-
               set -euxo pipefail
@@ -39,61 +43,49 @@ step_bundles:
               API_BASE_URL='$API_BASE_URL'" > ./.env
               echo "Check if the file was properly created: "
               wc .env
+          title: Script - create .env file
       - nvm@1:
-          title: Node Version Manager (NVM) - install Node.js
           inputs:
           - node_version: *node_version
+          title: Node Version Manager (NVM) - install Node.js
+      - restore-npm-cache@2: {}
       - install-react-native@0:
           inputs:
           - version: *react_native_cli_version
           title: Install React Native - CLI tools
       - yarn@0:
-          title: Run yarn command - install
           inputs:
           - command: install
+          title: Run yarn command - install
+      - save-npm-cache@1: {}
+  setup-steps-android:
+    description: |-
+      Install Android-specific dependencies.
+    steps:
+      - set-java-version@1:
+          inputs:
+          - set_java_version: *java_version_ndk
       - install-missing-android-tools@3:
           inputs:
-          - gradlew_path: "$PROJECT_LOCATION/gradlew"
+          - gradlew_path: "$GRADLEW_PATH"
           - ndk_version: *android_ndk_version
           is_always_run: true
-  release_steps:
+      - set-java-version@1:
+          inputs:
+          - set_java_version: *java_version
+  setup-steps-ios:
     description: |-
-      Bundle the Android app and copy the APK to $BITRISE_DEPLOY_DIR.
-      Currently, filenames are hardcoded, but they could be parameterized.
+      Install iOS-specific dependencies.
     steps:
-      - yarn@0:
-          title: Run yarn command - bundle:android
+      - restore-cocoapods-cache: {}
+      - cocoapods-install@2:
           inputs:
-          - command: bundle:android
-      - gradle-runner@3:
-          title: Gradle Runner - assembleRelease
-          inputs:
-          - apk_file_exclude_filter: "*-unaligned.apk\n\n"
-          - cache_level: all
-          - gradle_task: assembleRelease
-      - script@1:
-          inputs:
-          - content: |-
-              set -euxo pipefail
-              cp $BITRISE_APK_PATH $BITRISE_DEPLOY_DIR/openboxes_test_b$BITRISE_BUILD_NUMBER.apk
-          title: Script - copy APK for deploy-to-bitrise-io step
-      - deploy-to-bitrise-io@2:
-          is_always_run: false
-          inputs:
-          - notify_email_list: "$TESTERS"
-          - notify_user_groups: owner, admins, developers
-          - deploy_path: "$BITRISE_DEPLOY_DIR/openboxes_test_b$BITRISE_BUILD_NUMBER.apk"
-
-workflows:
-  app_distribution_to_testers:
+          - source_root_path: "$BITRISE_SOURCE_DIR/ios"
+      - save-cocoapods-cache: {}
+  branding:
+    description: |-
+      Apply modifications for branding.
     steps:
-    - bundle::setup_steps: {}
-    - bundle::release_steps: {}
-    triggers:
-      enabled: false
-  primary:
-    steps:
-    - bundle::setup_steps: {}
     - brew-install@1:
         inputs:
         - packages: jq
@@ -104,41 +96,133 @@ workflows:
         - command: branding:vipr
         is_skippable: true
         title: Run yarn command - branding:vipr
-    - bundle::release_steps: {}
+  release-steps-android:
+    description: |-
+      Assemble the Android app and copy the APK to $BITRISE_DEPLOY_DIR.
+      Currently, filenames are hardcoded, but they could be parameterized.
+    steps:
+      - yarn@0:
+          inputs:
+          - command: bundle:android
+          title: Run yarn command - bundle:android
+      - restore-gradle-cache@2: {}
+      - gradle-runner@3:
+          inputs:
+          - apk_file_exclude_filter: "*-unaligned.apk\n\n"
+          - cache_level: all
+          - gradle_task: assembleRelease
+          title: Gradle Runner - assembleRelease
+      - save-gradle-cache@1: {}
+      - script@1:
+          inputs:
+          - content: |-
+              set -euxo pipefail
+              cp $BITRISE_APK_PATH $BITRISE_DEPLOY_DIR/openboxes_test_b$BITRISE_BUILD_NUMBER.apk
+          title: Script - copy APK for deploy-to-bitrise-io step
+      - deploy-to-bitrise-io@2:
+          inputs:
+          - deploy_path: "$BITRISE_DEPLOY_DIR/openboxes_test_b$BITRISE_BUILD_NUMBER.apk"
+          - notify_email_list: "$TESTERS"
+          - notify_user_groups: owner, admins, developers
+          is_always_run: false
+  release-steps-ios:
+    description: |-
+      Assemble the iOS app and copy the *.app package to $BITRISE_DEPLOY_DIR.
+    steps:
+      - yarn@0:
+          inputs:
+          - command: bundle:ios
+          title: Run yarn command - bundle:ios
+      - script@1:
+          inputs:
+          - content: |-
+              set -euxo pipefail
+              plutil -lint "$BITRISE_SOURCE_DIR/ios/openboxes_mobile_o.xcodeproj/project.pbxproj"
+              swift --version
+              xcodebuild -version
+          title: Script - check project.pbxproj validity and Xcode version
+      - xcode-build-for-simulator@3:
+          inputs:
+          - export_method: "$BITRISE_EXPORT_METHOD"
+          - project_path: "$BITRISE_PROJECT_PATH"
+          - scheme: "$BITRISE_SCHEME"
+      - deploy-to-bitrise-io@2:
+          inputs:
+          - deploy_path: "$BITRISE_XCODEBUILD_BUILD_FOR_SIMULATOR_LOG_PATH"
+          - notify_user_groups: developers
+          is_always_run: true
+          title: Deploy to Bitrise.io - Xcode build log
+      - deploy-to-bitrise-io@2:
+          inputs:
+          - deploy_path: "$BITRISE_APP_DIR_PATH"
+          - notify_email_list: "$TESTERS"
+          - notify_user_groups: owner, admins, developers
+          is_always_run: false
+workflows:
+  app_distribution_to_testers:
+    steps:
+    - bundle::setup-steps: {}
+    - bundle::setup-steps-android: {}
+    - bundle::setup-steps-ios: {}
+    - bundle::release-steps-android: {}
+    - bundle::release-steps-ios: {}
+    triggers:
+      enabled: false
+  android-only:
+    steps:
+    - bundle::setup-steps: {}
+    - bundle::setup-steps-android: {}
+    - bundle::branding: {}
+    - bundle::release-steps-android: {}
+    triggers:
+      enabled: false
+  ios-only:
+    steps:
+    - bundle::setup-steps: {}
+    - bundle::setup-steps-ios: {}
+    - bundle::branding: {}
+    - bundle::release-steps-ios: {}
     triggers:
       enabled: false
 app:
   envs:
   - opts:
       is_expand: false
+    BITRISE_EXPORT_METHOD: development
+  - opts:
+      is_expand: false
+    BITRISE_PROJECT_PATH: ios/openboxes_mobile_o.xcworkspace
+  - opts:
+      is_expand: false
+    BITRISE_SCHEME: openboxes_mobile_o
+  - opts:
+      is_expand: false
     GRADLE_BUILD_FILE_PATH: android/build.gradle
+  - opts:
+      is_expand: false
+    #
+    # The --add-opens=... argument prevents the following error and may not be
+    # necessary in the future (e.g., if we upgrade Gradle or React Native):
+    #   java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.lang.String java.io.File.path accessible: module java.base does not "opens java.io" to unnamed module @4191eb2a
+    #
+    GRADLE_OPTS:
+      -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError --add-opens=java.base/java.io=ALL-UNNAMED"
   - opts:
       is_expand: false
     GRADLEW_PATH: android/gradlew
   - opts:
       is_expand: false
-    PROJECT_LOCATION: android
+    JAVA_OPTS: "-Xms512m -Xmx2048m"
   - opts:
       is_expand: false
     MODULE: app
   - opts:
       is_expand: false
+    PROJECT_LOCATION: android
+  - opts:
+      is_expand: false
     VARIANT: staging
-  - opts:
-      is_expand: false
-    BITRISE_PROJECT_PATH: ios/openboxesexpo.xcworkspace
-  - opts:
-      is_expand: false
-    BITRISE_SCHEME: openboxesexpo
-  - opts:
-      is_expand: false
-    BITRISE_EXPORT_METHOD: development
-  - opts:
-      is_expand: false
-    GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"
-  - opts:
-      is_expand: false
-    JAVA_OPTS: "-Xms512m -Xmx2048m"
+
 meta:
   bitrise.io:
-    stack: osx-xcode-14.3.x-ventura
+    stack: osx-xcode-16.4.x

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Openboxes mobile app built using React Native.
 
 ## ⭐ Prerequisites
 
-**iOS** : XCode(10.2) onwards
+**iOS** : XCode(16.4) onwards
 
 **Android** : Android Studio(3.4) with gradle(5.1.1) onwards
 
@@ -19,7 +19,7 @@ Openboxes mobile app built using React Native.
 
 **Step 3:** Install the dependencies with `yarn install`
 
-**Step 4:** Run the npm script to install the cocoapods `yarn pod install`
+**Step 4:** [iOS only] Run the npm script to install the cocoapods with `yarn pod install`
 
 ## 🕵️ How to Run the Project
 
@@ -49,6 +49,15 @@ Openboxes mobile app built using React Native.
      npm run android -release // .env
      ```
    - Note: These npm scripts will lint your code first. If there are no lint errors, then it will run the iOS or Android app. Otherwise it will show the lint errors in the terminal.
+
+## How to Package the Project
+  - Package iOS app
+    1. `yarn install`
+    2. `yarn pod install`
+    3. `yarn bundle:ios`
+    4. `yarn package:ios`
+
+    After running these four commands, look for `ios/build/openboxes_mobile_o.app`. If you are paranoid, and want to launch the `.app` in a simulator, replace step 4 with `yarn package:ios:simulate`.
 
 ## 🧶 Coding Style
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,6 +152,27 @@ android {
             }
         }
     }
+
+    lintOptions {
+        /*
+         * FIXME these should be removed once we move to RN 0.68+.
+         * FIXME Sentry-Android-Replay requires Kotlin 1.8, but
+         * FIXME the rest of the project is still on Kotlin 1.4.
+         *
+         * These prevent warnings in Task :app:lintVitalRelease like the following:
+         *
+         * - WARN: Unable to load JNA library (OS: Mac OS X 15.4.1)
+         * - java.lang.UnsatisfiedLinkError: Can't load library: /Users/vagrant/Library/Caches/JNA/temp/jna15644812717468529511.tmp
+         * - w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath
+         * - w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
+         *
+         * see https://developer.android.com/reference/tools/gradle-api/4.2/com/android/build/api/dsl/LintOptions
+         */
+        abortOnError false
+        checkReleaseBuilds false
+        disable 'JnaCheck'
+    }
+
     splits {
         abi {
             reset()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ios/.bundle/config
+++ b/ios/.bundle/config
@@ -1,0 +1,2 @@
+BUNDLE_PATH: "vendor/bundle"
+BUNDLE_FORCE_RUBY_PLATFORM: 1

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
+ruby '3.2.6'
+
+gem 'cocoapods', '~> 1.11', '>= 1.11.2'

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,0 +1,119 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.7)
+      base64
+      nkf
+      rexml
+    activesupport (7.2.2.1)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    algoliasearch (1.27.5)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    base64 (0.3.0)
+    benchmark (0.4.1)
+    bigdecimal (3.2.2)
+    claide (1.1.0)
+    cocoapods (1.16.2)
+      addressable (~> 2.8)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.16.2)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 2.1, < 3.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.8.0)
+      nap (~> 1.0)
+      ruby-macho (>= 2.3.0, < 3.0)
+      xcodeproj (>= 1.27.0, < 2.0)
+    cocoapods-core (1.16.2)
+      activesupport (>= 5.0, < 8)
+      addressable (~> 2.8)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.1)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+      netrc (~> 0.11)
+      public_suffix (~> 4.0)
+      typhoeus (~> 1.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (2.1)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.2.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.3)
+    drb (2.2.3)
+    escape (0.0.4)
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
+    ffi (1.17.2)
+    ffi (1.17.2-arm64-darwin)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    json (2.12.2)
+    logger (1.7.0)
+    minitest (5.25.5)
+    molinillo (0.8.0)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
+    nap (1.1.0)
+    netrc (0.11.0)
+    nkf (0.2.0)
+    public_suffix (4.0.7)
+    rexml (3.4.1)
+    ruby-macho (2.5.1)
+    securerandom (0.4.1)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    xcodeproj (1.27.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
+
+PLATFORMS
+  arm64-darwin-24
+  ruby
+
+DEPENDENCIES
+  cocoapods (~> 1.11, >= 1.11.2)
+
+RUBY VERSION
+   ruby 3.2.6p234
+
+BUNDLED WITH
+   2.4.19

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -63,6 +63,13 @@ target 'openboxes_mobile_o' do
           config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', '_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION']
         end
 
+        # Without this, Sentry fills build logs with warnings like:
+        #   `using '@_implementationOnly' without enabling library evolution for 'Sentry' may lead to instability during execution`
+        #
+        if target.name == 'Sentry'
+          config.build_settings['SWIFT_ENABLE_LIBRARY_EVOLUTION'] = 'YES'
+        end
+
         #
         # Prevent Yoga from breaking the build with this compiler warning:
         #   `error: use of bitwise '|' with boolean operands`
@@ -71,6 +78,12 @@ target 'openboxes_mobile_o' do
         if target.name == 'Yoga'
           config.build_settings['OTHER_CPLUSPLUSFLAGS'] ||= ['$(inherited)', '-Wno-error=bitwise-instead-of-logical']
         end
+
+        #
+        # Prevent xcodebuild from failing with this error:
+        #   `openboxes-mobile/ios/Pods/Pods.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 11.0, but the range of supported deployment target versions is 12.0 to 18.5.99. (in target '***' from project 'Pods')`
+        #
+        config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
       end
     end
 

--- a/ios/openboxes_mobile_o.xcodeproj/project.pbxproj
+++ b/ios/openboxes_mobile_o.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		506D39602E0A17EE004D99D0 /* main.jsbundle in Resources */ = {isa = PBXBuildFile; fileRef = 506D395F2E0A17EE004D99D0 /* main.jsbundle */; };
 		C220EE2490E348D0606C0B6C /* libPods-openboxes_mobile_o-openboxes_mobile_oTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 147055B32E3E16E71C1D78F6 /* libPods-openboxes_mobile_o-openboxes_mobile_oTests.a */; };
 		EB8C40E25F999CF2F1346ED7 /* libPods-openboxes_mobile_o.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 56DDFD0D801FF2C67315C04F /* libPods-openboxes_mobile_o.a */; };
 /* End PBXBuildFile section */
@@ -31,6 +32,7 @@
 /* Begin PBXFileReference section */
 		147055B32E3E16E71C1D78F6 /* libPods-openboxes_mobile_o-openboxes_mobile_oTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-openboxes_mobile_o-openboxes_mobile_oTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		390394A6108AC59D8F0D747D /* Pods-openboxes_mobile_o-openboxes_mobile_oTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-openboxes_mobile_o-openboxes_mobile_oTests.debug.xcconfig"; path = "Target Support Files/Pods-openboxes_mobile_o-openboxes_mobile_oTests/Pods-openboxes_mobile_o-openboxes_mobile_oTests.debug.xcconfig"; sourceTree = "<group>"; };
+		506D395F2E0A17EE004D99D0 /* main.jsbundle */ = {isa = PBXFileReference; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		508DBF962DEA39F70074B3AF /* openboxes_mobile_o.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = openboxes_mobile_o.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		508DBFB12DEA39F80074B3AF /* openboxes_mobile_oTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = openboxes_mobile_oTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		508DBFBB2DEA39F80074B3AF /* openboxes_mobile_oUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = openboxes_mobile_oUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -61,15 +63,11 @@
 		};
 		508DBFB42DEA39F80074B3AF /* openboxes_mobile_oTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = openboxes_mobile_oTests;
 			sourceTree = "<group>";
 		};
 		508DBFBE2DEA39F80074B3AF /* openboxes_mobile_oUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			exceptions = (
-			);
 			path = openboxes_mobile_oUITests;
 			sourceTree = "<group>";
 		};
@@ -105,6 +103,7 @@
 		508DBF8D2DEA39F70074B3AF = {
 			isa = PBXGroup;
 			children = (
+				506D395F2E0A17EE004D99D0 /* main.jsbundle */,
 				508DBF982DEA39F70074B3AF /* openboxes_mobile_o */,
 				508DBFB42DEA39F80074B3AF /* openboxes_mobile_oTests */,
 				508DBFBE2DEA39F80074B3AF /* openboxes_mobile_oUITests */,
@@ -263,6 +262,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				506D39602E0A17EE004D99D0 /* main.jsbundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -313,9 +313,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o/Pods-openboxes_mobile_o-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o/Pods-openboxes_mobile_o-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -330,9 +334,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o-openboxes_mobile_oTests/Pods-openboxes_mobile_o-openboxes_mobile_oTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o-openboxes_mobile_oTests/Pods-openboxes_mobile_o-openboxes_mobile_oTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -347,9 +355,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o-openboxes_mobile_oTests/Pods-openboxes_mobile_o-openboxes_mobile_oTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o-openboxes_mobile_oTests/Pods-openboxes_mobile_o-openboxes_mobile_oTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -386,9 +398,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o/Pods-openboxes_mobile_o-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-openboxes_mobile_o/Pods-openboxes_mobile_o-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -452,6 +468,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -481,6 +498,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -547,7 +565,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -604,7 +622,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -622,7 +640,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NURV32KUUY;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.openboxes.openboxes-mobile-oTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -641,7 +659,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NURV32KUUY;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.openboxes.openboxes-mobile-oTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -658,6 +676,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NURV32KUUY;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.openboxes.openboxes-mobile-oUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -674,6 +693,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = NURV32KUUY;
 				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.openboxes.openboxes-mobile-oUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/openboxes_mobile_o/Info.plist
+++ b/ios/openboxes_mobile_o/Info.plist
@@ -37,6 +37,11 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>RCTBundleURLProvider</key>
+	<dict>
+			<key>BundleURL</key>
+			<string>main.jsbundle</string>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/package.json
+++ b/package.json
@@ -6,13 +6,21 @@
     "android": "react-native run-android",
     "branding:vipr": "./scripts/apply_branding.sh vipr",
     "bundle:android": "mkdir -p android/app/src/main/assets && npx react-native bundle --entry-file index.js --platform android --bundle-output android/app/src/main/assets/index.android.bundle --dev true",
+    "bundle:ios": "mkdir -p ios/build && (xattr -w com.apple.xcode.CreatedByBuildSystem true ios/build || true) && npx react-native bundle --entry-file index.js --platform ios --bundle-output ios/main.jsbundle --assets-dest ios/build --dev true",
+    "clean": "yarn clean:android && yarn clean:ios && yarn clean:node_modules && yarn watchman:reset",
+    "clean:android": "rm android/app/src/main/assets/index.android.bundle || true && cd android && ./gradlew clean",
+    "clean:ios": "rm -rf ios/build ios/Pods && cd ios && xcodebuild clean",
+    "clean:node_modules": "rm -rf node_modules",
     "format": "prettier-eslint --eslint-config-path ./.eslintrc.js --write '**/*.ts' '**/*.tsx' '**/*.js' '**/*.jsx'",
     "ios": "react-native run-ios --simulator='iPhone 16'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "package:ios": "xcodebuild clean build -allowProvisioningUpdates -archivePath ios/build/Products/OpenBoxes.xcarchive -configuration Debug -derivedDataPath ios/build -scheme openboxes_mobile_o -sdk iphonesimulator -workspace ./ios/openboxes_mobile_o.xcworkspace && cp -R ./ios/build/Build/Products/Debug-iphonesimulator/openboxes_mobile_o.app ios/build",
+    "package:ios:simulate": "yarn package:ios && (xcrun simctl boot 'iPhone 16' || true) && open -a Simulator && xcrun simctl install booted ios/build/openboxes_mobile_o.app && xcrun simctl launch booted com.openboxes.openboxes-mobile-o",
     "pod": "yarn postinstall && cd ios && pod",
     "postinstall": "find node_modules -type f -name '*.podspec' -exec sed -i.pre-postinstall.bak 's|https://boostorg\\.jfrog\\.io/artifactory/main/|https://archives.boost.io/|g' {} +",
     "start": "npx react-native start --verbose",
-    "test": "jest"
+    "test": "jest",
+    "watchman:reset": "watchman watch-del . && watchman watch-project ."
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "~1.15.9",


### PR DESCRIPTION
Changes in this PR include the following, but the diff will be pretty noisy against develop. It'll be easier to spot the differences once #314 is merged. Or just look at 5ff54ea. (There are two other commits in here, each of which targets a small build nit: df99087, 464e8e0.)

    - update the bitrise stack to one that uses the latest Xcode
      - changes I made in previous PRs are not readable by earlier versions
      - also, the stack we are using will be removed in three months anyway
    - use Java 17 when needed to install dependencies, but keep Java 11 for builds
    - patch xcode files to accept a bundle built with yarn instead of npx
    - add two new yarn targets: bundle:ios and package:ios
    - resolve a few clang warnings and errors
    - enable build caching
    - bump gradle wrapper from 6.9 to 7.6.5, to work on latest XCode stack
    - prevent build errors/warnings in :app:lintVitalRelease by disabling it
