### PR TITLE
OBLS-287 improve discrepancy reason input, add putaway complete alert…

### DIFF
--- a/src/components/AsyncModalSelect/index.tsx
+++ b/src/components/AsyncModalSelect/index.tsx
@@ -60,41 +60,52 @@ const AsyncModalSelect = ({
 
   return (
     <View style={styles.mainContainer}>
-      <ModalSelector
-        accessible
-        initValue=""
-        cancelText="Cancel"
-        supportedOrientations={['landscape']}
-        optionContainerStyle={styles.container}
-        optionTextStyle={styles.option}
-        scrollViewAccessibilityLabel={'Scrollable options'}
-        data={data.map((item) => ({
-          key: item.key || item.id,
-          label: item.label || item.name
-        }))}
-        cancelButtonAccessibilityLabel={'Cancel Button'}
-        searchText="Search for more options..."
-        onChange={(option: { label: React.SetStateAction<string>; key: any }) => {
-          setLabel(option.label);
-          onSelect?.({ id: option.key, name: option.label });
-        }}
-        onSearchFilterer={
-          serverSearchEnabled
-            ? (searchText, unfilteredData) => unfilteredData
-            : (searchText, unfilteredData) =>
-                unfilteredData.filter((item) =>
-                  (item.label || '').toLowerCase().includes((searchText || '').toLowerCase())
-                )
-        }
-        onChangeSearch={serverSearchEnabled ? debounceOnSearchTerm : undefined}
-      >
-        <TextInput style={styles.textInput} editable={false} placeholder={placeholder || ''} value={label} />
-      </ModalSelector>
-      {label ? (
-        <TouchableOpacity onPress={clearSelection}>
-          <Image source={CLEAR} style={styles.imageIcon} />
-        </TouchableOpacity>
-      ) : null}
+      <View style={styles.inputContainer}>
+        <ModalSelector
+          accessible
+          initValue=""
+          cancelText="Cancel"
+          supportedOrientations={['landscape']}
+          optionContainerStyle={styles.container}
+          optionTextStyle={styles.option}
+          scrollViewAccessibilityLabel="Scrollable options"
+          data={data.map((item) => ({
+            key: item.key || item.id,
+            label: item.label || item.name
+          }))}
+          cancelButtonAccessibilityLabel="Cancel Button"
+          searchText="Search for more options..."
+          renderItem={() => null}
+          onChange={(option: { label: string; key: any }) => {
+            setLabel(option.label);
+            onSelect?.({ id: option.key, name: option.label });
+          }}
+          onSearchFilterer={
+            serverSearchEnabled
+              ? (searchText, unfilteredData) => unfilteredData
+              : (searchText, unfilteredData) =>
+                  unfilteredData.filter((item) =>
+                    (item.label || '').toLowerCase().includes((searchText || '').toLowerCase())
+                  )
+          }
+          onChangeSearch={serverSearchEnabled ? debounceOnSearchTerm : undefined}
+        >
+          <TextInput
+            multiline
+            style={styles.textInput}
+            editable={false}
+            textAlignVertical="center"
+            placeholder={placeholder || ''}
+            value={label}
+          />
+        </ModalSelector>
+
+        {label ? (
+          <TouchableOpacity style={styles.imageIconContainer} onPress={clearSelection}>
+            <Image source={CLEAR} style={styles.imageIcon} />
+          </TouchableOpacity>
+        ) : null}
+      </View>
     </View>
   );
 };

--- a/src/components/AsyncModalSelect/styles.ts
+++ b/src/components/AsyncModalSelect/styles.ts
@@ -5,31 +5,11 @@ export default StyleSheet.create({
   mainContainer: {
     marginVertical: 5
   },
-  itemContainer: {
-    flex: 1,
-    marginTop: 5,
-    height: 25,
-    borderColor: 'grey'
-  },
-  autoCompleteContainer: {
-    borderWidth: 2,
-    borderRadius: 4,
-    flexDirection: 'row',
-    backgroundColor: 'white',
-    borderColor: 'grey',
-    justifyContent: 'center',
-    paddingHorizontal: 10
-  },
-  autoCompleteInputContainer: {
-    borderWidth: 1
-  },
-  clearButton: {
-    width: 25,
-    height: 25,
-    margin: 5
-  },
   container: {
     backgroundColor: 'white'
+  },
+  inputContainer: {
+    position: 'relative'
   },
   option: {
     color: 'black'
@@ -37,21 +17,26 @@ export default StyleSheet.create({
   textInput: {
     borderWidth: 1,
     borderColor: 'grey',
-    padding: Theme.spacing.medium,
-    height: 55,
+    paddingVertical: Theme.spacing.medium,
+    paddingLeft: Theme.spacing.medium,
+    paddingRight: 40,
+    minHeight: 55,
     borderRadius: Theme.roundness,
     marginBottom: Theme.spacing.small,
-    color: 'black'
+    color: 'black',
+    textAlignVertical: 'top'
   },
-  imageIcon: {
+  imageIconContainer: {
     position: 'absolute',
-    end: Theme.spacing.medium,
-    width: 30,
-    height: 30,
-    bottom: 20,
-    padding: 10,
+    top: '50%',
+    right: Theme.spacing.small,
+    transform: [{ translateY: -18 }],
     justifyContent: 'center',
     alignItems: 'center',
-    zIndex: 100
+    zIndex: 10
+  },
+  imageIcon: {
+    width: 30,
+    height: 30
   }
 });

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -120,13 +120,8 @@ export default function PutawayLocationScanScreen() {
 
           <View style={styles.topSpace}>
             <View style={[styles.headerRow, styles.bottomSpace]}>
-              <Paragraph style={styles.paragraph}>Alternative Location?</Paragraph>
-              <Button
-                style={styles.secondaryButton}
-                size="50%"
-                title="Request"
-                onPress={() => setIsDialogVisible(true)}
-              />
+              <Paragraph style={styles.subheading}>Alternative Location?</Paragraph>
+              <Button size="50%" title="Request" onPress={() => setIsDialogVisible(true)} />
             </View>
           </View>
 

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -119,7 +119,7 @@ export default function PutawayQuantityScreen() {
       dispatch(
         patchPutawayTaskAction(putawayDetails.facility.id, putawayDetails.id, payload, (response) => {
           if (response && !response.error) {
-            Alert.alert('Sortation Successful', 'The product has been sorted successfully.');
+            Alert.alert('Putaway Successful', 'The putaway was successful.');
             const nextTaskIndex = currentTaskIndex + 1;
             if (nextTaskIndex < taskList.length) {
               navigate('SortationPutawayLocationScan', {
@@ -135,7 +135,7 @@ export default function PutawayQuantityScreen() {
               }
             }
           } else {
-            Alert.alert('Sortation Failed', response.errorMessage || 'Sortation Failed');
+            Alert.alert('Putaway Failed', response.errorMessage || 'Putaway Failed');
           }
         })
       );
@@ -204,17 +204,12 @@ export default function PutawayQuantityScreen() {
 
           <View style={styles.topSpace}>
             <View style={[styles.headerRow, styles.bottomSpace]}>
-              <Paragraph style={styles.paragraph}>Alternative Location?</Paragraph>
-              <Button
-                style={styles.secondaryButton}
-                size="50%"
-                title="Request"
-                onPress={() => setIsDialogVisible(true)}
-              />
+              <Paragraph style={styles.subheading}>Alternative Location?</Paragraph>
+              <Button size="50%" title="Request" onPress={() => setIsDialogVisible(true)} />
             </View>
 
             <View style={styles.headerRow}>
-              <Paragraph style={styles.paragraph}>Discrepancy Reason</Paragraph>
+              <Paragraph style={styles.subheading}>Discrepancy Reason</Paragraph>
               <View style={styles.dropdownContainer}>
                 <AsyncModalSelect
                   placeholder="Select a reason"
@@ -230,7 +225,7 @@ export default function PutawayQuantityScreen() {
           </View>
 
           <View style={styles.cardAnnotation}>
-            <Paragraph style={[styles.paragraph]}>Cancel Remaining</Paragraph>
+            <Paragraph style={[styles.subheading]}>Cancel Remaining</Paragraph>
             <Switch
               value={isCancelRemainingEnabled}
               color={Theme.colors.primary}

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -74,9 +74,6 @@ export default StyleSheet.create({
     flexDirection: 'column',
     padding: Theme.spacing.large
   },
-  secondaryButton: {
-    height: 35
-  },
   modalOverlay: {
     flex: 1,
     justifyContent: 'center',


### PR DESCRIPTION
… after putaway

[OBLS-287](https://openboxes.atlassian.net/browse/OBLS-287)

Changes:
- break words in the discrepancy reason input, make X to not overlap the content
<img width="366" height="69" alt="image" src="https://github.com/user-attachments/assets/8172c993-a211-4174-9025-16f2f894dd28" />

- show `putaway successful` alert instead of `sortation completed` (same applies to fail)
<img width="320" height="144" alt="image" src="https://github.com/user-attachments/assets/3a7af9f3-4119-4685-92fb-2f455baa93e3" />
