### PR TITLE
OBLS-334 support short pick

### DIFF
--- a/src/apis/picking.ts
+++ b/src/apis/picking.ts
@@ -1,4 +1,4 @@
-import { DeliveryTypeCode } from '../types/picking';
+import { DeliveryTypeCode, ReasonCode } from '../types/picking';
 import ApiClient from '../utils/ApiClient';
 
 export type PickTaskParams = {
@@ -17,6 +17,14 @@ export type PickTaskActionParams =
       outboundContainerId: string;
       // User Id
       pickedById: string;
+    }
+  | {
+      action: 'short-pick';
+      outboundContainerId: string;
+      quantityPicked: number;
+      pickedById: string;
+      // eslint-disable-next-line no-undef
+      reasonCode?: Pick<ReasonCode, 'name'>;
     };
 
 export type PickTaskDropParams = {
@@ -53,5 +61,13 @@ export function getPickTasksByStatusAndContainerApi(facilityId: string, outbound
     `/facilities/${facilityId}/pick-tasks?outboundContainerId=${encodeURIComponent(
       outboundContainerId
     )}&status=${encodeURIComponent(status)}`
+  );
+}
+
+export function getPickTasksByRequisitionApi(facilityId: string, requisitionId: string, statuses: string[]) {
+  return ApiClient.get(
+    `/facilities/${facilityId}/pick-tasks?requisitionId=${encodeURIComponent(requisitionId)}&${statuses
+      .map((status) => `status=${encodeURIComponent(status)}`)
+      .join('&')}`
   );
 }

--- a/src/redux/actions/picking.ts
+++ b/src/redux/actions/picking.ts
@@ -25,6 +25,14 @@ export const GET_PICKED_TASKS_BY_CONTAINER_REQUEST = 'GET_PICKED_TASKS_BY_CONTAI
 export const GET_PICKED_TASKS_BY_CONTAINER_REQUEST_SUCCESS = 'GET_PICKED_TASKS_BY_CONTAINER_REQUEST_SUCCESS';
 export const GET_PICKED_TASKS_BY_CONTAINER_REQUEST_FAIL = 'GET_PICKED_TASKS_BY_CONTAINER_REQUEST_FAIL';
 
+export const SHORT_PICK_TASK_REQUEST = 'SHORT_PICK_TASK_REQUEST';
+export const SHORT_PICK_TASK_REQUEST_SUCCESS = 'SHORT_PICK_TASK_REQUEST_SUCCESS';
+export const SHORT_PICK_TASK_REQUEST_FAIL = 'SHORT_PICK_TASK_REQUEST_FAIL';
+
+export const GET_PICK_TASKS_BY_REQUISITION_REQUEST = 'GET_PICK_TASKS_BY_REQUISITION_REQUEST';
+export const GET_PICK_TASKS_BY_REQUISITION_REQUEST_SUCCESS = 'GET_PICK_TASKS_BY_REQUISITION_REQUEST_SUCCESS';
+export const GET_PICK_TASKS_BY_REQUISITION_REQUEST_FAIL = 'GET_PICK_TASKS_BY_REQUISITION_REQUEST_FAIL';
+
 export function getPickTasksAction(
   params: PickTaskParams,
   callback: (response: {
@@ -45,6 +53,27 @@ export function getPickTasksAction(
   };
 }
 
+export function getPickTasksByRequisitionAction(
+  requisitionId: string,
+  callback: (response: {
+    response?: {
+      data: PickTask[];
+      errorCode?: string;
+      message?: string;
+      max?: number;
+      offset?: number;
+      totalCount?: number;
+    };
+    errorMessage?: string;
+  }) => void
+) {
+  return {
+    type: GET_PICK_TASKS_BY_REQUISITION_REQUEST,
+    payload: { requisitionId },
+    callback
+  };
+}
+
 export function startPickTaskAction(taskId: string, callback: (response: { errorMessage?: string }) => void) {
   return {
     type: START_PICK_TASK_REQUEST,
@@ -61,6 +90,20 @@ export function pickPickTaskAction(
   return {
     type: PICK_PICK_TASK_REQUEST,
     payload: { taskId, outboundContainerId },
+    callback
+  };
+}
+
+export function shortPickTaskAction(
+  taskId: string,
+  outboundContainerId: string,
+  quantityPicked: number,
+  callback: (response: { errorMessage?: string }) => void,
+  reasonCode?: string
+) {
+  return {
+    type: SHORT_PICK_TASK_REQUEST,
+    payload: { taskId, quantityPicked, reasonCode, outboundContainerId },
     callback
   };
 }

--- a/src/redux/sagas/picking.ts
+++ b/src/redux/sagas/picking.ts
@@ -9,6 +9,9 @@ import {
   GET_PICK_TASK_BY_ID_REQUEST,
   GET_PICK_TASK_BY_ID_REQUEST_FAIL,
   GET_PICK_TASK_BY_ID_REQUEST_SUCCESS,
+  GET_PICK_TASKS_BY_REQUISITION_REQUEST,
+  GET_PICK_TASKS_BY_REQUISITION_REQUEST_SUCCESS,
+  GET_PICK_TASKS_BY_REQUISITION_REQUEST_FAIL,
   GET_PICK_TASKS_REQUEST,
   GET_PICK_TASKS_REQUEST_FAIL,
   GET_PICK_TASKS_REQUEST_SUCCESS,
@@ -18,6 +21,9 @@ import {
   PICK_PICK_TASK_REQUEST,
   PICK_PICK_TASK_REQUEST_FAIL,
   PICK_PICK_TASK_REQUEST_SUCCESS,
+  SHORT_PICK_TASK_REQUEST,
+  SHORT_PICK_TASK_REQUEST_FAIL,
+  SHORT_PICK_TASK_REQUEST_SUCCESS,
   START_PICK_TASK_REQUEST,
   START_PICK_TASK_REQUEST_FAIL,
   START_PICK_TASK_REQUEST_SUCCESS
@@ -114,6 +120,41 @@ function* pickPickTaskAction(action: any) {
   }
 }
 
+function* shortPickTaskAction(action: any) {
+  try {
+    // @ts-ignore
+    const currentLocation = yield select(userLocation);
+    if (!currentLocation) {
+      throw new Error('User Location Not Found');
+    }
+    // @ts-ignore
+    const session = yield select(userSession);
+    if (!session || !session.user) {
+      throw new Error('User Session Not Found');
+    }
+    yield put(showScreenLoading('Shorting Pick Task...'));
+    const { taskId, outboundContainerId, quantityPicked, reasonCode } = action.payload;
+    // Short Pick Task API Call
+    yield call(api.patchPickTaskApi, currentLocation.id, taskId, {
+      action: 'short-pick',
+      outboundContainerId,
+      quantityPicked,
+      pickedById: session.user.id,
+      reasonCode
+    });
+    yield put({ type: SHORT_PICK_TASK_REQUEST_SUCCESS });
+    yield action.callback({});
+    yield put(hideScreenLoading());
+  } catch (error) {
+    yield put({
+      type: SHORT_PICK_TASK_REQUEST_FAIL,
+      payload: (error as any)?.message || 'Error Shorting Pick Task'
+    });
+    yield action.callback({ errorMessage: (error as any)?.message || 'Error Shorting Pick Task' });
+    yield put(hideScreenLoading());
+  }
+}
+
 function* dropPickTaskAction(action: any) {
   try {
     // @ts-ignore
@@ -194,7 +235,34 @@ function* getPickedTasksByContainerAction(action: any) {
       type: GET_PICKED_TASKS_BY_CONTAINER_REQUEST_FAIL,
       payload: (error as any)?.message || 'Error Fetching Picked Tasks'
     });
-    yield action.callback({ error });
+    yield action.callback({ errorMessage: (error as any)?.message || 'Error Fetching Picked Tasks' });
+    yield put(hideScreenLoading());
+  }
+}
+
+function* getPickTasksByRequisitionAction(action: any) {
+  try {
+    // @ts-ignore
+    const currentLocation = yield select(userLocation);
+    if (!currentLocation) {
+      throw new Error('User Location Not Found');
+    }
+    yield put(showScreenLoading('Fetching Tasks...'));
+    // Call API to get pick tasks by requisition ID
+    // @ts-ignore
+    const response = yield call(api.getPickTasksByRequisitionApi, currentLocation.id, action.payload.requisitionId, [
+      'PENDING',
+      'PICKING'
+    ]);
+    yield action.callback({ response });
+    yield put({ type: GET_PICK_TASKS_BY_REQUISITION_REQUEST_SUCCESS, payload: response.data });
+    yield put(hideScreenLoading());
+  } catch (error) {
+    yield put({
+      type: GET_PICK_TASKS_BY_REQUISITION_REQUEST_FAIL,
+      payload: (error as any)?.message || 'Error Fetching Tasks By Requisition'
+    });
+    yield action.callback({ errorMessage: (error as any)?.message || 'Error Fetching Tasks By Requisition' });
     yield put(hideScreenLoading());
   }
 }
@@ -206,4 +274,6 @@ export default function* watcher() {
   yield takeLatest(DROP_PICK_TASK_REQUEST, dropPickTaskAction);
   yield takeLatest(GET_PICK_TASK_BY_ID_REQUEST, getPickTaskByIdAction);
   yield takeLatest(GET_PICKED_TASKS_BY_CONTAINER_REQUEST, getPickedTasksByContainerAction);
+  yield takeLatest(SHORT_PICK_TASK_REQUEST, shortPickTaskAction);
+  yield takeLatest(GET_PICK_TASKS_BY_REQUISITION_REQUEST, getPickTasksByRequisitionAction);
 }

--- a/src/screens/Picking/PickingContext.tsx
+++ b/src/screens/Picking/PickingContext.tsx
@@ -7,7 +7,9 @@ import {
   dropPickTaskAction,
   getPickTaskByIdAction,
   getPickTasksAction,
+  getPickTasksByRequisitionAction,
   pickPickTaskAction,
+  shortPickTaskAction,
   startPickTaskAction
 } from '../../redux/actions/picking';
 import { DeliveryType, PickTask } from '../../types/picking';
@@ -15,6 +17,8 @@ import { DeliveryType, PickTask } from '../../types/picking';
 type PickingContextType = {
   /** The list of all tasks for this session */
   tasks: PickTask[];
+  /** Setter for the list of tasks */
+  setTasks: React.Dispatch<React.SetStateAction<PickTask[]>>;
   /** The index of the task currently being worked on */
   currentTaskIndex: number;
   /** The derived object for the active task */
@@ -27,8 +31,15 @@ type PickingContextType = {
   pickCurrentTask: (outboundContainerId: string, callback: (response: { errorMessage?: string }) => void) => void;
   /** Resets state to initial values */
   resetSession: () => void;
-  /** Handle partial pick for the current task */
-  handlePartialPick: () => void;
+  /** Handles short pick for the current task */
+  shortPickTask: (
+    outboundContainerId: string,
+    parsedQuantityPicked: number,
+    callback: (response: { errorMessage?: string }) => void,
+    reasonCodeName?: string
+  ) => void;
+  /** Revalidates all tasks for a given requisition ID */
+  revalidateTasksForRequisition: (requisitionId: string | undefined, callback?: () => void) => void;
   /** Start the pick task (API call) */
   startPickTask: (callback: (response: { errorMessage?: string }) => void) => void;
   /** Drop the current pick task at the staging location */
@@ -89,6 +100,20 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
     dispatch(pickPickTaskAction(currentTask.id, outboundContainerId, callback));
   };
 
+  const shortPickTask = (
+    outboundContainerId: string,
+    parsedQuantityPicked: number,
+    callback: (response: { errorMessage?: string }) => void,
+    reasonCodeName?: string
+  ) => {
+    if (!currentTask || parsedQuantityPicked === undefined) {
+      Alert.alert('Error', 'Missing required fields for short pick.');
+      return;
+    }
+
+    dispatch(shortPickTaskAction(currentTask.id, outboundContainerId, parsedQuantityPicked, callback, reasonCodeName));
+  };
+
   const revalidateCurrentTask = (callback?: (task: PickTask) => void) => {
     if (!currentTask) {
       return;
@@ -104,6 +129,41 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
         const updatedTask = response.data;
         setTasks((prevTasks) => prevTasks.map((task, index) => (index === currentTaskIndex ? updatedTask : task)));
         callback?.(updatedTask);
+      })
+    );
+  };
+
+  const revalidateTasksForRequisition = (requisitionId: string | undefined, callback?: () => void) => {
+    if (!requisitionId) {
+      Alert.alert('Error', 'Requisition ID is required to revalidate tasks.');
+      return;
+    }
+
+    dispatch(
+      getPickTasksByRequisitionAction(requisitionId, (res) => {
+        if ('errorMessage' in res) {
+          Alert.alert('Error', 'Failed to revalidate pick tasks for the requisition.');
+          return;
+        }
+
+        const newTasks = res.response?.data ?? [];
+
+        setTasks((prevTasks) => {
+          const currentIndex = currentTaskIndex;
+          const current = prevTasks[currentIndex];
+
+          if (!current) {
+            return prevTasks;
+          }
+
+          // Remove all existing tasks belonging to this requisition
+          const filteredTasks = prevTasks.filter((task) => task.requisitionId !== requisitionId);
+
+          // Insert new tasks where the current one was
+          return [...filteredTasks.slice(0, currentIndex), ...newTasks, ...filteredTasks.slice(currentIndex)];
+        });
+
+        callback?.();
       })
     );
   };
@@ -127,9 +187,6 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
     dispatch(dropPickTaskAction(task.outboundContainer.id, task.stagingLocation.id, callback));
   };
 
-  // TODO: Implement partial pick logic
-  const handlePartialPick = () => {};
-
   const resetSession = () => {
     setTasks([]);
     setCurrentTaskIndex(0);
@@ -143,13 +200,15 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
     <PickingContext.Provider
       value={{
         tasks,
+        setTasks,
         currentTaskIndex,
         currentTask,
         allTasksCount,
         startSession,
         pickCurrentTask,
+        shortPickTask,
         resetSession,
-        handlePartialPick,
+        revalidateTasksForRequisition,
         startPickTask,
         dropCurrentTask,
         revalidateCurrentTask,

--- a/src/screens/Picking/PickingPickLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickLocationScreen.tsx
@@ -38,6 +38,7 @@ export default function PickingPickLocationScreen() {
         'Invalid Barcode',
         `Incorrect location scanned. Expected: ${currentTask?.location?.locationNumber}. Try again.`
       );
+      setPickLocationBarcode('');
       return;
     }
 

--- a/src/screens/Picking/PickingPickLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickLocationScreen.tsx
@@ -68,7 +68,11 @@ export default function PickingPickLocationScreen() {
 
         <ProductDetails.List
           items={[
-            { icon: 'truck', label: 'Quantity Required', value: currentTask.quantityRequired },
+            {
+              icon: 'package',
+              label: 'Quantity Picked',
+              value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`
+            },
             { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || HYPHEN }
           ]}
         />

--- a/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
+++ b/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
@@ -90,6 +90,7 @@ export default function PickingPickOutboundContainerScreen() {
         ({ errorMessage }) => {
           if (errorMessage) {
             Alert.alert('Short Pick Error', errorMessage);
+            setOutboundContainerId('');
             return;
           }
 

--- a/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
+++ b/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
@@ -1,17 +1,33 @@
-import { useIsFocused } from '@react-navigation/native';
+import { RouteProp, useIsFocused, useRoute } from '@react-navigation/native';
 import * as React from 'react';
 import { Alert, TextInput, View } from 'react-native';
 import { Divider, TextInput as PaperTextInput, Paragraph, Subheading } from 'react-native-paper';
 
 import { INPUT_FOCUS_DELAY_TIME_IN_MS } from '../../constants';
 import { navigate } from '../../NavigationService';
+import { ReasonCode } from '../../types/picking';
 import { usePickingContext } from './PickingContext';
 import { ProductDetails } from './ProductDetails';
 import styles from './styles';
 
+type PickingPickOutboundContainerScreenProps = RouteProp<
+  { PickingPickOutboundContainer: { reasonCode?: ReasonCode; quantityPicked?: string } },
+  'PickingPickOutboundContainer'
+>;
+
 export default function PickingPickOutboundContainerScreen() {
-  const { currentTask, pickCurrentTask, currentTaskIndex, allTasksCount, revalidateCurrentTask, goToNextTask } =
-    usePickingContext();
+  const {
+    currentTask,
+    pickCurrentTask,
+    shortPickTask,
+    currentTaskIndex,
+    allTasksCount,
+    revalidateCurrentTask,
+    goToNextTask,
+    revalidateTasksForRequisition
+  } = usePickingContext();
+  const { params } = useRoute<PickingPickOutboundContainerScreenProps>();
+  const parsedQuantityPicked = params?.quantityPicked ? Number(params.quantityPicked) : undefined;
 
   const inputRef = React.useRef<TextInput | null>(null);
   const isFocused = useIsFocused();
@@ -32,9 +48,62 @@ export default function PickingPickOutboundContainerScreen() {
     return null;
   }
 
+  function revalidateTaskAndProceed() {
+    revalidateCurrentTask((revalidatedTask) => {
+      if (!revalidatedTask) {
+        Alert.alert('Error', 'Failed to revalidate the current pick task after picking.');
+        return;
+      }
+
+      if (currentTaskIndex + 1 >= allTasksCount) {
+        // Last Task -> Navigate to staging location drop
+        Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
+          {
+            text: 'OK',
+            onPress: () => navigate('PickingPickStagingLocation')
+          }
+        ]);
+      } else {
+        // More Tasks -> Start over with next pick task
+        goToNextTask();
+        navigate('PickingPickLocation');
+      }
+    });
+  }
+
   function handleSubmit() {
     if (!outboundContainerId) {
       Alert.alert('Missing Input', 'Please scan or enter a valid Outbound Container ID.');
+      return;
+    }
+
+    if (!currentTask) {
+      Alert.alert('Error', 'No current pick task available.');
+      return;
+    }
+
+    if (parsedQuantityPicked !== undefined && parsedQuantityPicked < currentTask.quantityRequired) {
+      // Handle Short Pick
+      shortPickTask(
+        outboundContainerId,
+        parsedQuantityPicked,
+        ({ errorMessage }) => {
+          if (errorMessage) {
+            Alert.alert('Short Pick Error', errorMessage);
+            return;
+          }
+
+          if (params?.reasonCode?.id) {
+            // Revalidate all tasks for the requisition to get updated pick tasks
+            revalidateTasksForRequisition(currentTask.requisitionId, () => {
+              navigate('PickingPickLocation');
+            });
+          } else {
+            revalidateTaskAndProceed();
+          }
+        },
+        params?.reasonCode?.name
+      );
       return;
     }
 
@@ -44,26 +113,7 @@ export default function PickingPickOutboundContainerScreen() {
         return;
       }
 
-      revalidateCurrentTask((revalidatedTask) => {
-        if (!revalidatedTask) {
-          Alert.alert('Error', 'Failed to revalidate the current pick task after picking.');
-          return;
-        }
-
-        if (currentTaskIndex + 1 >= allTasksCount) {
-          // Last Task -> Navigate to staging location drop
-          Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
-            {
-              text: 'OK',
-              onPress: () => navigate('PickingPickStagingLocation')
-            }
-          ]);
-        } else {
-          // More Tasks -> Start over with next pick task
-          goToNextTask();
-          navigate('PickingPickLocation');
-        }
-      });
+      revalidateTaskAndProceed();
     });
   }
 
@@ -84,12 +134,10 @@ export default function PickingPickOutboundContainerScreen() {
 
         <ProductDetails.List
           items={[
-            // NOTE: For now, we assume quantity picked equals quantity required.
-            // This might change in the future if we implement partial picks.
             {
               icon: 'truck',
               label: 'Quantity Picked',
-              value: currentTask.quantityPicked || currentTask.quantityRequired
+              value: params?.quantityPicked || currentTask.quantityRequired
             },
             {
               icon: 'pin',

--- a/src/screens/Picking/PickingPickProductScreen.tsx
+++ b/src/screens/Picking/PickingPickProductScreen.tsx
@@ -39,6 +39,7 @@ export default function PickingPickProductScreen() {
         'Invalid Barcode',
         `Incorrect product scanned. Expected: ${currentTask?.product.productCode}. Please try again.`
       );
+      setProductBarcode('');
       return;
     }
 

--- a/src/screens/Picking/PickingPickProductScreen.tsx
+++ b/src/screens/Picking/PickingPickProductScreen.tsx
@@ -62,7 +62,11 @@ export default function PickingPickProductScreen() {
 
         <ProductDetails.List
           items={[
-            { icon: 'truck', label: 'Quantity Required', value: currentTask.quantityRequired },
+            {
+              icon: 'package',
+              label: 'Quantity Picked',
+              value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`
+            },
             { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || HYPHEN }
           ]}
         />

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -37,7 +37,7 @@ export default function PickingPickQuantityScreen() {
   // Fetch reason codes
   React.useEffect(() => {
     dispatch(
-      getReasonCodesAction('PUTAWAY_DISCREPANCY', (data: any) => {
+      getReasonCodesAction('PICKING_SHORTAGE', (data: any) => {
         if (data?.error) {
           Alert.alert('Error', 'Failed to load reason codes.');
         } else {

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -14,19 +14,14 @@ import { ProductDetails } from './ProductDetails';
 import styles from './styles';
 
 export default function PickingPickQuantityScreen() {
-  const {
-    currentTask,
-    currentTaskIndex,
-    allTasksCount
-    // handlePartialPick
-  } = usePickingContext();
+  const { currentTask, currentTaskIndex, allTasksCount } = usePickingContext();
   const dispatch = useDispatch();
   const inputRef = React.useRef<TextInput | null>(null);
   const isFocused = useIsFocused();
 
   const [quantityPicked, setQuantityPicked] = React.useState<string>('');
   const [reasonCodes, setReasonCodes] = React.useState<ReasonCode[]>([]);
-  const [selectedReasonCode, setSelectedReasonCode] = React.useState<ReasonCode | null>(null);
+  const [selectedReasonCode, setSelectedReasonCode] = React.useState<ReasonCode | undefined>(undefined);
   const [isShortModalVisible, setIsShortModalVisible] = React.useState(false);
 
   // Focus input when screen is focused
@@ -58,23 +53,18 @@ export default function PickingPickQuantityScreen() {
 
   function handleSubmit() {
     const qty = Number(quantityPicked);
-    const isValid = !isNaN(qty) && qty >= 0;
-    const isFullPicked = qty === currentTask?.quantityRequired;
-    const is0Picked = qty === 0;
-
-    if (qty > (currentTask?.quantityRequired ?? 0)) {
-      Alert.alert('Invalid Quantity', 'Picked quantity cannot exceed required quantity.');
-      return;
-    }
+    const isValid = !isNaN(qty) && qty >= 0 && currentTask?.quantityRequired;
 
     if (!isValid) {
       Alert.alert('Invalid Quantity', 'Incorrect quantity picked. Please try again.');
       return;
     }
 
-    // NOTE: Not supported yet
-    if (is0Picked) {
-      setIsShortModalVisible(true);
+    const qtyRemaining = currentTask?.quantityRequired - (currentTask?.quantityPicked || 0);
+    const isFullPicked = qty === qtyRemaining;
+
+    if (qty > qtyRemaining) {
+      Alert.alert('Invalid Quantity', `Picked quantity cannot exceed remaining quantity to pick (${qtyRemaining}).`);
       return;
     }
 
@@ -83,27 +73,14 @@ export default function PickingPickQuantityScreen() {
       return;
     }
 
-    Alert.alert(
-      'Partial Pick Recorded',
-      `You have picked ${qty} units. The remaining quantity will need to be picked later.`,
-      [
-        {
-          text: 'OK',
-          onPress: () => setQuantityPicked('')
-        }
-      ]
-    );
-
-    // TODO: Handle partial pick
-    // Handle partial pick
-    // handlePartialPick(qty);
+    // For now, if not full picked, treat as short pick
+    setIsShortModalVisible(true);
   }
 
-  function handleConfirmShort(reasonCode: ReasonCode) {
+  function handleConfirmShort(reasonCode: ReasonCode | undefined) {
     setIsShortModalVisible(false);
-    // TODO: Handle short pick with reason code
-    // eslint-disable-next-line no-restricted-syntax
-    console.log(reasonCode);
+
+    navigate('PickingPickOutboundContainer', { reasonCode, quantityPicked });
   }
 
   return (
@@ -124,7 +101,11 @@ export default function PickingPickQuantityScreen() {
 
           <ProductDetails.List
             items={[
-              { icon: 'truck', label: 'Quantity Required', value: currentTask.quantityRequired },
+              {
+                icon: 'package',
+                label: 'Quantity Picked',
+                value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`
+              },
               { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || HYPHEN }
             ]}
           />
@@ -161,6 +142,7 @@ export default function PickingPickQuantityScreen() {
         reasonCodes={reasonCodes}
         selectedReasonCode={selectedReasonCode}
         setSelectedReasonCode={setSelectedReasonCode}
+        quantityPicked={quantityPicked}
         onDismiss={() => setIsShortModalVisible(false)}
         onConfirm={handleConfirmShort}
       />

--- a/src/screens/Picking/PickingPickTypeScreen.tsx
+++ b/src/screens/Picking/PickingPickTypeScreen.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Alert, ScrollView, TouchableOpacity, View } from 'react-native';
 import { Badge, Button, TextInput as PaperTextInput, Paragraph, Subheading, Title } from 'react-native-paper';
-
 import Icon, { Name } from '../../components/Icon';
 import { navigate } from '../../NavigationService';
 import { DeliveryType } from '../../types/picking';
@@ -27,15 +26,19 @@ export default function PickingPickTypeScreen() {
   async function handleConfirmQuantity() {
     const ordersCount = Number(numberOfOrdersToGroup);
 
-    if (ordersCount > NUMBER_OF_ORDERS_THRESHOLD) {
-      Alert.alert(
-        'Max Number Exceeded',
-        `The maximum number of orders to group is ${NUMBER_OF_ORDERS_THRESHOLD}. Please adjust your input.`
-      );
+    // Validate that input is numeric and an integer within range
+    if (
+      !numberOfOrdersToGroup ||
+      isNaN(ordersCount) ||
+      !Number.isInteger(ordersCount) ||
+      ordersCount < 1 ||
+      ordersCount > NUMBER_OF_ORDERS_THRESHOLD
+    ) {
+      Alert.alert('Invalid Number', `Please enter a whole number between 1 and ${NUMBER_OF_ORDERS_THRESHOLD}.`);
       return;
     }
 
-    if (!deliveryType || !numberOfOrdersToGroup) {
+    if (!deliveryType) {
       Alert.alert(
         'Missing Information',
         'Please select a pick type and specify the number of orders to group before proceeding.'
@@ -89,6 +92,7 @@ export default function PickingPickTypeScreen() {
           keyboardType="numeric"
           value={numberOfOrdersToGroup}
           onChangeText={setNumberOfOrdersToGroup}
+          onSubmitEditing={handleConfirmQuantity}
         />
 
         <Button

--- a/src/screens/Picking/PickingShortAndReasonModal.tsx
+++ b/src/screens/Picking/PickingShortAndReasonModal.tsx
@@ -9,10 +9,11 @@ import styles from './styles';
 type Props = {
   visible: boolean;
   onDismiss: () => void;
-  onConfirm: (reasonCode: ReasonCode) => void;
+  onConfirm: (reasonCode?: ReasonCode) => void;
   reasonCodes: ReasonCode[];
-  selectedReasonCode: ReasonCode | null;
-  setSelectedReasonCode: (reasonCode: ReasonCode | null) => void;
+  selectedReasonCode: ReasonCode | undefined;
+  setSelectedReasonCode: (reasonCode: ReasonCode | undefined) => void;
+  quantityPicked?: string;
 };
 
 export default function PickingShortAndReasonModal({
@@ -21,23 +22,20 @@ export default function PickingShortAndReasonModal({
   onConfirm,
   reasonCodes,
   selectedReasonCode,
-  setSelectedReasonCode
+  setSelectedReasonCode,
+  quantityPicked
 }: Props) {
-  const onSelectedReason = (reason: ReasonCode) => {
-    // We need this because of the AsyncModalSelect implementation
-    if (!reason.id || !reason.name) {
-      setSelectedReasonCode(null);
-      return;
-    }
+  const parsedQuantityPicked = quantityPicked ? Number(quantityPicked) : 0;
 
-    setSelectedReasonCode(reason);
-  };
+  // We need this because of the AsyncModalSelect implementation
+  const onSelectedReason = (reason?: ReasonCode) =>
+    !reason?.id || !reason?.name ? setSelectedReasonCode(undefined) : setSelectedReasonCode(reason);
 
   return (
     <Modal transparent animationType="slide" visible={visible} onRequestClose={onDismiss}>
       <View style={styles.modalOverlay}>
         <View style={styles.modalContent}>
-          <Subheading style={styles.modalTitleText}>Return Or Short-Pick</Subheading>
+          <Subheading style={styles.modalTitleText}>Proceed With Short-Pick</Subheading>
           <Paragraph style={styles.modalDescription}>
             Select a reason for shortage to proceed with “Short” or press “Return” to enter a correct quantity.
           </Paragraph>
@@ -58,8 +56,9 @@ export default function PickingShortAndReasonModal({
             </Button>
             <Button
               mode="contained"
-              disabled={!selectedReasonCode}
-              onPress={() => selectedReasonCode && onConfirm(selectedReasonCode)}
+              // If quantity picked is zero, reason code selection is mandatory
+              disabled={parsedQuantityPicked === 0 ? !selectedReasonCode : false}
+              onPress={() => onConfirm(selectedReasonCode)}
             >
               Short
             </Button>

--- a/src/screens/Picking/PickingShortAndReasonModal.tsx
+++ b/src/screens/Picking/PickingShortAndReasonModal.tsx
@@ -54,12 +54,7 @@ export default function PickingShortAndReasonModal({
             <Button mode="text" onPress={onDismiss}>
               Return
             </Button>
-            <Button
-              mode="contained"
-              // If quantity picked is zero, reason code selection is mandatory
-              disabled={parsedQuantityPicked === 0 ? !selectedReasonCode : false}
-              onPress={() => onConfirm(selectedReasonCode)}
-            >
+            <Button mode="contained" onPress={() => onConfirm(selectedReasonCode)}>
               Short
             </Button>
           </View>

--- a/src/screens/Picking/PickingShortAndReasonModal.tsx
+++ b/src/screens/Picking/PickingShortAndReasonModal.tsx
@@ -54,7 +54,12 @@ export default function PickingShortAndReasonModal({
             <Button mode="text" onPress={onDismiss}>
               Return
             </Button>
-            <Button mode="contained" onPress={() => onConfirm(selectedReasonCode)}>
+            <Button
+              mode="contained"
+              // If quantity picked is zero, reason code selection is mandatory
+              disabled={parsedQuantityPicked === 0 ? !selectedReasonCode : false}
+              onPress={() => onConfirm(selectedReasonCode)}
+            >
               Short
             </Button>
           </View>


### PR DESCRIPTION
[OBLS-334](https://openboxes.atlassian.net/browse/OBLS-334)

General Picking Overview
0:00 – 0:23:
Short Pick — picking 3 out of 5. A reason code is provided.
Result: A new pick task is generated for the remaining quantity, and I’m automatically redirected to it.

0:24 – 0:57:
Short Pick — picking 0 out of 2. A reason code is provided.
Result: Same outcome as before, although this flow will be updated since picking 0 qty and placing it into a container is simply dumb.

0:58 – 1:25:
Short Pick — picking 1 out of 2, no reason code provided.
Result: I proceed to drop the picked items at the staging location. The remaining task (quantity of 1) stays pickable.

1:32 – 1:59:
Restarting the picking process — I pick up the remaining quantity (1) from the previous task.
Result: Proceed through the standard picking flow and complete the task.

https://github.com/user-attachments/assets/c48a7daf-fbba-4220-b2d3-93f5fa035860
