### PR TITLE
OBLS-284 add info about current barcode, clear input on edit

### DIFF
--- a/src/screens/ProductDetails/EditBarcodeModal.tsx
+++ b/src/screens/ProductDetails/EditBarcodeModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal, View, Keyboard } from 'react-native';
-import { Button, Headline, Paragraph, TextInput } from 'react-native-paper';
+import { Keyboard, Modal, View } from 'react-native';
+import { Button, Headline, Paragraph, Subheading, TextInput } from 'react-native-paper';
+
 import Theme from '../../utils/Theme';
 import styles from './styles';
 
@@ -12,11 +13,11 @@ type EditBarcodeModalProps = {
 };
 
 export default function EditBarcodeModal({ visible, currentBarcode, onSave, onClose }: EditBarcodeModalProps) {
-  const [barcode, setBarcode] = useState(currentBarcode || '');
+  const [barcode, setBarcode] = useState('');
   const inputRef = useRef<any>(null);
 
   useEffect(() => {
-    setBarcode(currentBarcode || '');
+    setBarcode('');
   }, [currentBarcode]);
 
   useEffect(() => {
@@ -33,10 +34,16 @@ export default function EditBarcodeModal({ visible, currentBarcode, onSave, onCl
       <View style={styles.modalOverlay}>
         <View style={styles.modalContent}>
           <Headline>Edit Barcode</Headline>
-          <Paragraph style={{ marginBottom: Theme.spacing.large }}>
+          <Paragraph style={{ marginBottom: Theme.spacing.medium }}>
             You'll be able to find and scan the product using either its internal product code or its barcode, depending
             on what your scanner provides.
           </Paragraph>
+
+          {currentBarcode ? (
+            <Subheading style={{ marginBottom: Theme.spacing.medium }}>
+              Current Barcode: <Paragraph style={styles.subheading}>{currentBarcode}</Paragraph>
+            </Subheading>
+          ) : null}
 
           <TextInput
             blurOnSubmit


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-284

Changes:
- Add info about current barcode (if exists).
- Clear the input when opening a modal (ready to scan).
<img width="332" height="317" alt="image" src="https://github.com/user-attachments/assets/add13013-fe15-44c8-b144-281f3eb3719b" />

Related PR:
https://github.com/openboxes/openboxes/pull/5665
