### PR TITLE
OBLS-373 set vvg server as a default api base url

### DIFF
--- a/src/utils/EnvironmentActual.ts
+++ b/src/utils/EnvironmentActual.ts
@@ -1,4 +1,4 @@
 import { Environment } from './Environment';
 export const EnvironmentActual: Environment = {
-  API_BASE_URL: 'https://cwg-test.etrucknow.com/openboxes/api'
+  API_BASE_URL: 'https://vvg.openboxes.com/openboxes/api'
 };


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-373

Changes:
- Set `https://vvg.openboxes.com/openboxes/api` as a default api base url