### PR TITLE
OBLS-630 Implement a user-directed putaway option

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -55,6 +55,8 @@ import SortationEntryScreen from './screens/Sortation/SortationEntryScreen';
 import SortationQuantityScreen from './screens/Sortation/SortationQuantityScreen';
 import SortationTaskSelectionListScreen from './screens/Sortation/SortationTaskSelectionListScreen';
 import PutawayEntryScreen from './screens/SortationPutaway/PutawayEntryScreen';
+import PutawayModeScreen from './screens/SortationPutaway/PutawayModeScreen';
+import PutawayTaskListScreen from './screens/SortationPutaway/PutawayTaskListScreen';
 import PutawayLocationScanScreen from './screens/SortationPutaway/PutawayLocationScanScreen';
 import PutawayProductScanScreen from './screens/SortationPutaway/PutawayProductScanScreen';
 import PutawayQuantityScreen from './screens/SortationPutaway/PutawayQuantityScreen';
@@ -306,6 +308,16 @@ class Main extends Component<Props, State> {
                 options={{ title: 'Inbound Sortation' }}
               />
               <Stack.Screen name="SortationPutaway" component={PutawayEntryScreen} options={{ title: 'Putaway' }} />
+              <Stack.Screen
+                name="SortationPutawayMode"
+                component={PutawayModeScreen}
+                options={{ title: 'Putaway Mode' }}
+              />
+              <Stack.Screen
+                name="SortationPutawayTaskList"
+                component={PutawayTaskListScreen}
+                options={{ title: 'Putaway Tasks' }}
+              />
               <Stack.Screen
                 name="SortationPutawayLocationScan"
                 component={PutawayLocationScanScreen}

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -13,7 +13,9 @@ export enum Name {
   Search,
   Category,
   Check,
-  ChevronRight
+  ChevronRight,
+  ChevronDown,
+  ChevronUp
 }
 
 export interface Props {
@@ -51,6 +53,12 @@ export default function Icon(props: Props) {
       break;
     case Name.ChevronRight:
       content = <Entypo name="chevron-right" style={props.style} size={props.size} color={props.color} />;
+      break;
+    case Name.ChevronDown:
+      content = <Entypo name="chevron-down" style={props.style} size={props.size} color={props.color} />;
+      break;
+    case Name.ChevronUp:
+      content = <Entypo name="chevron-up" style={props.style} size={props.size} color={props.color} />;
       break;
   }
 

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -24,7 +24,6 @@ export interface Props {
   onPress?: () => void;
   color?: string;
   style?: StyleProp<TextStyle>;
-  focusable?: boolean;
 }
 
 export default function Icon(props: Props) {

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -12,7 +12,8 @@ export enum Name {
   Cross,
   Search,
   Category,
-  Check
+  Check,
+  ChevronRight
 }
 
 export interface Props {
@@ -21,6 +22,7 @@ export interface Props {
   onPress?: () => void;
   color?: string;
   style?: StyleProp<TextStyle>;
+  focusable?: boolean;
 }
 
 export default function Icon(props: Props) {
@@ -47,6 +49,10 @@ export default function Icon(props: Props) {
     case Name.Check:
       content = <Entypo name="check" style={props.style} size={props.size} color={props.color} />;
       break;
+    case Name.ChevronRight:
+      content = <Entypo name="chevron-right" style={props.style} size={props.size} color={props.color} />;
+      break;
   }
-  return <TouchableOpacity onPress={props.onPress}>{content}</TouchableOpacity>;
+
+  return props.onPress ? <TouchableOpacity onPress={props.onPress}>{content}</TouchableOpacity> : content;
 }

--- a/src/redux/reducers/putawayReducer.ts
+++ b/src/redux/reducers/putawayReducer.ts
@@ -1,6 +1,8 @@
+import { SortationTask } from '../../types/sortation';
 import {
   FETCH_PUTAWAY_FROM_ORDER_REQUEST_SUCCESS,
   GET_PUTAWAY_CANDIDATES_REQUEST_SUCCESS,
+  GET_PUTAWAY_DETAILS_BY_CONTAINER_ID_REQUEST_SUCCESS,
   SUBMIT_PUTAWAY_ITEM_BIN_LOCATION_SUCCESS
 } from '../actions/putaways';
 
@@ -8,12 +10,14 @@ export interface State {
   putAway: any;
   putAwayItem: any;
   candidates: any;
+  putawayTasks: SortationTask[];
 }
 
 const initialState: State = {
   putAway: null,
   putAwayItem: null,
-  candidates: []
+  candidates: [],
+  putawayTasks: []
 };
 
 function reducer(state = initialState, action: any) {
@@ -36,7 +40,16 @@ function reducer(state = initialState, action: any) {
         putAwayItem: action.payload
       };
     }
-
+    case GET_PUTAWAY_DETAILS_BY_CONTAINER_ID_REQUEST_SUCCESS: {
+      const allTasks = action.payload || [];
+      const filteredTasks = allTasks.filter(
+        (task: SortationTask) => task.status === 'IN_PROGRESS' || task.status === 'PENDING'
+      );
+      return {
+        ...state,
+        putawayTasks: filteredTasks
+      };
+    }
     default: {
       return state;
     }

--- a/src/redux/sagas/putaway.ts
+++ b/src/redux/sagas/putaway.ts
@@ -132,13 +132,17 @@ function* getPutawayDetailsByContainerId(action: any) {
       payload: response.data
     });
     yield put(hideScreenLoading());
-    yield action.callback({ response, message: 'Putaway details fetched successfully' });
+    if (action.callback) {
+      yield action.callback({ response, message: 'Putaway details fetched successfully' });
+    }
   } catch (error) {
     yield put(hideScreenLoading());
-    yield action.callback({
-      error: true,
-      errorMessage: error.message
-    });
+    if (action.callback) {
+      yield action.callback({
+        error: true,
+        errorMessage: error.message
+      });
+    }
   }
 }
 

--- a/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
+++ b/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
@@ -7,14 +7,14 @@ import Button from '../../components/Button';
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
 import { getAlternativeDestinationsAction, searchLocationByLocationNumber } from '../../redux/actions/locations';
-import { PutawayDetailsModel, SortationLocation } from '../../types/sortation';
+import { SortationLocation, SortationTask } from '../../types/sortation';
 import styles from './styles';
 
 type Props = {
   visible: boolean;
   onDismiss: () => void;
   onConfirm: (location: SortationLocation) => void;
-  putawayDetails: PutawayDetailsModel;
+  putawayDetails: SortationTask;
   initialLocation: SortationLocation | null;
 };
 

--- a/src/screens/SortationPutaway/PutawayDetails.tsx
+++ b/src/screens/SortationPutaway/PutawayDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, View } from 'react-native';
-import { Caption, Chip, Divider, Title } from 'react-native-paper';
+import { Chip, Divider, Title } from 'react-native-paper';
 
 import { EMPTY_FALLBACK } from '../../constants';
 import { DetailChip, PutawayDetailsModel } from '../../types/sortation';
@@ -8,10 +8,18 @@ import styles from './styles';
 
 type PutawayDetailsProps = {
   putawayDetails: PutawayDetailsModel;
+  taskIndex?: number;
+  totalTasks?: number;
+  showTaskCounter?: boolean;
 };
 
-export default function PutawayDetails({ putawayDetails }: PutawayDetailsProps) {
-  const { inventoryItem, quantity, container, destination, type } = putawayDetails;
+export default function PutawayDetails({
+  putawayDetails,
+  taskIndex,
+  totalTasks,
+  showTaskCounter = true
+}: PutawayDetailsProps) {
+  const { inventoryItem, quantity, container, destination } = putawayDetails;
 
   const detailsChips: DetailChip[] = [
     {
@@ -39,9 +47,14 @@ export default function PutawayDetails({ putawayDetails }: PutawayDetailsProps) 
             Product Code: <Text style={styles.bold}>{inventoryItem?.product?.productCode}</Text>
           </Text>
         </Chip>
-        <Chip style={[styles.chipWarning]} textStyle={styles.chipText}>
-          {`${type ?? EMPTY_FALLBACK}`}
-        </Chip>
+        {showTaskCounter && taskIndex !== undefined && totalTasks !== undefined && (
+          <Chip icon="navigation" style={styles.chipDefault} textStyle={styles.chipText}>
+            Tasks:{' '}
+            <Text style={styles.bold}>
+              {taskIndex + 1} / {totalTasks}
+            </Text>
+          </Chip>
+        )}
       </View>
 
       <Divider style={styles.contentDivider} />

--- a/src/screens/SortationPutaway/PutawayDetails.tsx
+++ b/src/screens/SortationPutaway/PutawayDetails.tsx
@@ -3,11 +3,11 @@ import { Text, View } from 'react-native';
 import { Chip, Divider, Title } from 'react-native-paper';
 
 import { EMPTY_FALLBACK } from '../../constants';
-import { DetailChip, PutawayDetailsModel } from '../../types/sortation';
+import { DetailChip, SortationTask } from '../../types/sortation';
 import styles from './styles';
 
 type PutawayDetailsProps = {
-  putawayDetails: PutawayDetailsModel;
+  putawayDetails: SortationTask;
   taskIndex?: number;
   totalTasks?: number;
   showTaskCounter?: boolean;

--- a/src/screens/SortationPutaway/PutawayEntryScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayEntryScreen.tsx
@@ -23,9 +23,9 @@ export default function PutawayEntryScreen() {
             const filteredTasks = allTasks.filter((task) => task.status === 'IN_PROGRESS' || task.status === 'PENDING');
 
             if (filteredTasks.length > 0) {
-              navigate('SortationPutawayLocationScan', {
-                taskList: filteredTasks,
-                currentTaskIndex: 0
+              navigate('SortationPutawayMode', {
+                containerId,
+                taskList: filteredTasks
               });
             } else {
               Alert.alert('No Valid Tasks Found', `No IN_PROGRESS tasks found for container ${containerId}`);

--- a/src/screens/SortationPutaway/PutawayEntryScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayEntryScreen.tsx
@@ -1,33 +1,31 @@
 import React, { useCallback, useState } from 'react';
 import { Alert, ScrollView } from 'react-native';
 import { Paragraph, Title } from 'react-native-paper';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
 import { navigate } from '../../NavigationService';
 import { getPutawayDetailsByContainerId } from '../../redux/actions/putaways';
-import { SortationTask } from '../../types/sortation';
+import { RootState } from '../../redux/reducers';
 import styles from './styles';
 
 export default function PutawayEntryScreen() {
   const [putawayContainerId, setPutawayContainerId] = useState<string>(EMPTY_STRING);
   const dispatch = useDispatch();
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks);
 
   const performScan = useCallback(
     (containerId: string) => {
       dispatch(
         getPutawayDetailsByContainerId(containerId, (response) => {
           if (response && !response.error) {
-            const allTasks: SortationTask[] = response?.response?.data || [];
-            const filteredTasks = allTasks.filter((task) => task.status === 'IN_PROGRESS' || task.status === 'PENDING');
-
-            if (filteredTasks.length > 0) {
+            if (putawayTasks.length > 0) {
               navigate('SortationPutawayMode', {
                 containerId
               });
             } else {
-              Alert.alert('No Valid Tasks Found', `No IN_PROGRESS tasks found for container ${containerId}`);
+              Alert.alert('No Valid Tasks Found', `No open tasks found for container ${containerId}`);
             }
           } else {
             Alert.alert('Error', `Error while fetching putaway tasks: ${response?.errorMessage}`);
@@ -37,7 +35,7 @@ export default function PutawayEntryScreen() {
         })
       );
     },
-    [dispatch]
+    [dispatch, putawayTasks]
   );
 
   return (

--- a/src/screens/SortationPutaway/PutawayEntryScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayEntryScreen.tsx
@@ -24,8 +24,7 @@ export default function PutawayEntryScreen() {
 
             if (filteredTasks.length > 0) {
               navigate('SortationPutawayMode', {
-                containerId,
-                taskList: filteredTasks
+                containerId
               });
             } else {
               Alert.alert('No Valid Tasks Found', `No IN_PROGRESS tasks found for container ${containerId}`);

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import { Alert, ScrollView, View } from 'react-native';
 import { Divider, Paragraph, Subheading } from 'react-native-paper';
 
-import Button from '../../components/Button';
 import EmptyView from '../../components/EmptyView';
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
@@ -13,6 +12,7 @@ import AlternativeLocationSelector from './AlternativeLocationSelector';
 import PutawayDetails from './PutawayDetails';
 import { SkipButton } from './SkipButton';
 import styles from './styles';
+import Button from '../../components/Button';
 
 type PutawayLocationScanRouteProp = RouteProp<
   {
@@ -23,7 +23,7 @@ type PutawayLocationScanRouteProp = RouteProp<
 
 export default function PutawayLocationScanScreen() {
   const { params } = useRoute<PutawayLocationScanRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway } = params;
+  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
   const putawayDetails = taskList[currentTaskIndex];
 
   const [putawayLocationBarcode, setPutawayLocationBarcode] = useState<string>(EMPTY_STRING);
@@ -51,9 +51,6 @@ export default function PutawayLocationScanScreen() {
     );
   }
 
-  /**
-   * Unifies validation for scanner input and button press
-   */
   function handleProcessing(code: string) {
     const expectedLocation = selectedAlternativeDestination?.locationNumber;
 
@@ -66,7 +63,6 @@ export default function PutawayLocationScanScreen() {
       return;
     }
 
-    // Prepare updated task
     const updatedTaskList = [...taskList];
     updatedTaskList[currentTaskIndex] = {
       ...putawayDetails,
@@ -76,7 +72,9 @@ export default function PutawayLocationScanScreen() {
     navigate('SortationPutawayProductScan', {
       taskList: updatedTaskList,
       currentTaskIndex,
-      isDirectPutaway
+      isDirectPutaway,
+      isUserDirected,
+      containerId
     });
   }
 
@@ -92,7 +90,12 @@ export default function PutawayLocationScanScreen() {
         style={styles.contentWrapper}
         contentContainerStyle={styles.contentContainer}
       >
-        <PutawayDetails putawayDetails={updatedPutawayDetails} />
+        <PutawayDetails
+          putawayDetails={updatedPutawayDetails}
+          taskIndex={currentTaskIndex}
+          totalTasks={taskList.length}
+          showTaskCounter={!isUserDirected}
+        />
 
         <Divider />
 
@@ -126,7 +129,17 @@ export default function PutawayLocationScanScreen() {
             Submit
           </Button>
 
-          <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+          {isUserDirected ? (
+            <Button
+              style={styles.topSpace}
+              title="Back To List"
+              mode="text"
+              size="100%"
+              onPress={() => navigate('SortationPutawayTaskList', { containerId })}
+            />
+          ) : (
+            <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+          )}
         </View>
       </ScrollView>
 

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -2,29 +2,37 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import React, { useEffect, useState } from 'react';
 import { Alert, ScrollView, View } from 'react-native';
 import { Divider, Paragraph, Subheading } from 'react-native-paper';
+import { useSelector } from 'react-redux';
 
+import Button from '../../components/Button';
 import EmptyView from '../../components/EmptyView';
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
 import { navigate } from '../../NavigationService';
-import { SortationLocation, SortationPutawayScreenType } from '../../types/sortation';
+import { RootState } from '../../redux/reducers';
+import { SortationLocation, SortationTask } from '../../types/sortation';
 import AlternativeLocationSelector from './AlternativeLocationSelector';
 import PutawayDetails from './PutawayDetails';
 import { SkipButton } from './SkipButton';
 import styles from './styles';
-import Button from '../../components/Button';
 
 type PutawayLocationScanRouteProp = RouteProp<
   {
-    SortationPutawayLocationScan: SortationPutawayScreenType;
+    SortationPutawayLocationScan: {
+      currentTaskIndex: number;
+      isDirectPutaway?: boolean;
+      isUserDirected?: boolean;
+      containerId?: string;
+    };
   },
   'SortationPutawayLocationScan'
 >;
 
 export default function PutawayLocationScanScreen() {
   const { params } = useRoute<PutawayLocationScanRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
-  const putawayDetails = taskList[currentTaskIndex];
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
+  const putawayDetails = putawayTasks?.[currentTaskIndex];
 
   const [putawayLocationBarcode, setPutawayLocationBarcode] = useState<string>(EMPTY_STRING);
   const [isDialogVisible, setIsDialogVisible] = useState(false);
@@ -63,14 +71,7 @@ export default function PutawayLocationScanScreen() {
       return;
     }
 
-    const updatedTaskList = [...taskList];
-    updatedTaskList[currentTaskIndex] = {
-      ...putawayDetails,
-      destination: selectedAlternativeDestination ?? putawayDetails.destination
-    };
-
     navigate('SortationPutawayProductScan', {
-      taskList: updatedTaskList,
       currentTaskIndex,
       isDirectPutaway,
       isUserDirected,
@@ -93,7 +94,7 @@ export default function PutawayLocationScanScreen() {
         <PutawayDetails
           putawayDetails={updatedPutawayDetails}
           taskIndex={currentTaskIndex}
-          totalTasks={taskList.length}
+          totalTasks={putawayTasks?.length || 0}
           showTaskCounter={!isUserDirected}
         />
 
@@ -138,7 +139,7 @@ export default function PutawayLocationScanScreen() {
               onPress={() => navigate('SortationPutawayTaskList', { containerId })}
             />
           ) : (
-            <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+            <SkipButton taskList={putawayTasks} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
           )}
         </View>
       </ScrollView>

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -46,7 +46,7 @@ export default function PutawayLocationScanScreen() {
 
   useEffect(() => {
     setPutawayLocationBarcode(EMPTY_STRING);
-  }, []);
+  }, [currentTaskIndex]);
 
   if (!putawayDetails) {
     return (

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -139,7 +139,12 @@ export default function PutawayLocationScanScreen() {
               onPress={() => navigate('SortationPutawayTaskList', { containerId })}
             />
           ) : (
-            <SkipButton taskList={putawayTasks} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+            <SkipButton
+              taskList={putawayTasks}
+              currentTaskIndex={currentTaskIndex}
+              isDirectPutaway={isDirectPutaway}
+              containerId={containerId}
+            />
           )}
         </View>
       </ScrollView>

--- a/src/screens/SortationPutaway/PutawayModeScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayModeScreen.tsx
@@ -4,14 +4,16 @@ import React, { useMemo } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Avatar, Chip, Divider, Paragraph, Subheading } from 'react-native-paper';
 
+import Icon from '../../components/Icon';
 import { SortationTask } from '../../types/sortation';
 import styles from './styles';
-import Icon from '../../components/Icon';
 
 type RootStackParamList = {
   SortationPutawayLocationScan: {
     taskList: SortationTask[];
     currentTaskIndex: number;
+    isUserDirected?: boolean;
+    containerId?: string;
   };
   SortationPutawayTaskList: {
     containerId: string;
@@ -19,7 +21,7 @@ type RootStackParamList = {
   };
 };
 
-type NavigationProp = StackNavigationProp<RootStackParamList>;
+type NavigationProp = StackNavigationProp<RootStackParamList, any>;
 
 type PutawayModeScreenProps = {
   route: {
@@ -43,7 +45,7 @@ function ModeCard({
 }) {
   return (
     <TouchableOpacity style={styles.modeCardContainer} activeOpacity={0.8} onPress={onPress}>
-      <View style={styles.modeCardLeft}>
+      <View style={styles.modeCardLeft} focusable={false}>
         <Avatar.Icon size={40} icon={icon} style={styles.modeCardAvatar} />
       </View>
       <View style={styles.modeCardContent}>
@@ -51,7 +53,7 @@ function ModeCard({
         <Text style={styles.modeCardDescription}>{description}</Text>
       </View>
       <View style={styles.modeCardRight} focusable={false}>
-        <Icon name={7} focusable={false} />
+        <Icon name={7} />
       </View>
     </TouchableOpacity>
   );
@@ -72,7 +74,9 @@ export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
   const handleSystemDirected = () => {
     navigation.navigate('SortationPutawayLocationScan', {
       taskList,
-      currentTaskIndex: 0
+      currentTaskIndex: 0,
+      isUserDirected: false,
+      containerId
     });
   };
 
@@ -91,11 +95,11 @@ export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
     >
       <View style={styles.productDetails}>
         <View style={styles.headerRow}>
-          <Chip icon="identifier" style={styles.chipDefault} textStyle={styles.chipText} focusable={false}>
-            Container Id: {containerId}
+          <Chip icon="identifier" style={styles.chipDefault} textStyle={styles.chipText}>
+            Container Id: <Text style={styles.bold}>{containerId}</Text>
           </Chip>
-          <Chip icon="package" style={styles.chipDefault} textStyle={styles.chipText} focusable={false}>
-            Tasks: {taskSummary.totalItems}
+          <Chip icon="package" style={styles.chipDefault} textStyle={styles.chipText}>
+            Tasks: <Text style={styles.bold}>{taskSummary.totalItems}</Text>
           </Chip>
         </View>
       </View>

--- a/src/screens/SortationPutaway/PutawayModeScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayModeScreen.tsx
@@ -1,0 +1,125 @@
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import React, { useMemo } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Avatar, Chip, Divider, Paragraph, Subheading } from 'react-native-paper';
+
+import { SortationTask } from '../../types/sortation';
+import styles from './styles';
+import Icon from '../../components/Icon';
+
+type RootStackParamList = {
+  SortationPutawayLocationScan: {
+    taskList: SortationTask[];
+    currentTaskIndex: number;
+  };
+  SortationPutawayTaskList: {
+    containerId: string;
+    taskList: SortationTask[];
+  };
+};
+
+type NavigationProp = StackNavigationProp<RootStackParamList>;
+
+type PutawayModeScreenProps = {
+  route: {
+    params: {
+      containerId: string;
+      taskList: SortationTask[];
+    };
+  };
+};
+
+function ModeCard({
+  title,
+  description,
+  icon,
+  onPress
+}: {
+  title: string;
+  description: string;
+  icon: string;
+  onPress: () => void;
+}) {
+  return (
+    <TouchableOpacity style={styles.modeCardContainer} activeOpacity={0.8} onPress={onPress}>
+      <View style={styles.modeCardLeft}>
+        <Avatar.Icon size={40} icon={icon} style={styles.modeCardAvatar} />
+      </View>
+      <View style={styles.modeCardContent}>
+        <Text style={styles.modeCardTitle}>{title}</Text>
+        <Text style={styles.modeCardDescription}>{description}</Text>
+      </View>
+      <View style={styles.modeCardRight} focusable={false}>
+        <Icon name={7} focusable={false} />
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
+  const { containerId, taskList } = route.params;
+  const navigation = useNavigation<NavigationProp>();
+
+  const taskSummary = useMemo(() => {
+    const zones = new Set(taskList.map((task) => task.destination?.zoneName).filter(Boolean));
+    return {
+      totalItems: taskList.length,
+      totalZones: zones.size
+    };
+  }, [taskList]);
+
+  const handleSystemDirected = () => {
+    navigation.navigate('SortationPutawayLocationScan', {
+      taskList,
+      currentTaskIndex: 0
+    });
+  };
+
+  const handleUserDirected = () => {
+    navigation.navigate('SortationPutawayTaskList', {
+      containerId,
+      taskList
+    });
+  };
+
+  return (
+    <ScrollView
+      keyboardShouldPersistTaps="always"
+      style={styles.contentWrapper}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View style={styles.productDetails}>
+        <View style={styles.headerRow}>
+          <Chip icon="identifier" style={styles.chipDefault} textStyle={styles.chipText} focusable={false}>
+            Container Id: {containerId}
+          </Chip>
+          <Chip icon="package" style={styles.chipDefault} textStyle={styles.chipText} focusable={false}>
+            Tasks: {taskSummary.totalItems}
+          </Chip>
+        </View>
+      </View>
+
+      <Divider />
+
+      <View style={styles.formContainer}>
+        <Subheading style={styles.subheading}>Choose a Putaway Mode</Subheading>
+        <Paragraph style={styles.paragraph}>Select how you want to manage your putaway tasks.</Paragraph>
+
+        <ModeCard
+          title="System Directed"
+          description="Follow the recommended putaway sequence"
+          icon="map-marker-path"
+          onPress={handleSystemDirected}
+        />
+
+        <ModeCard
+          title="User Directed"
+          description="Select tasks in any order and putaway as you go"
+          icon="account-group"
+          onPress={handleUserDirected}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/src/screens/SortationPutaway/PutawayModeScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayModeScreen.tsx
@@ -97,7 +97,11 @@ export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
             Container Id: <Text style={styles.bold}>{containerId}</Text>
           </Chip>
           <Chip icon="package" style={styles.chipDefault} textStyle={styles.chipText}>
-            Tasks: <Text style={styles.bold}>{taskSummary.totalItems}</Text>
+            Tasks:{' '}
+            <Text style={styles.bold}>
+              {taskSummary.totalItems} item{taskSummary.totalItems !== 1 ? 's' : ''} across {taskSummary.totalZones}{' '}
+              zone{taskSummary.totalZones !== 1 ? 's' : ''}
+            </Text>
           </Chip>
         </View>
       </View>

--- a/src/screens/SortationPutaway/PutawayModeScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayModeScreen.tsx
@@ -3,21 +3,21 @@ import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useMemo } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Avatar, Chip, Divider, Paragraph, Subheading } from 'react-native-paper';
+import { useSelector } from 'react-redux';
 
-import Icon from '../../components/Icon';
+import Icon, { Name } from '../../components/Icon';
+import { RootState } from '../../redux/reducers';
 import { SortationTask } from '../../types/sortation';
 import styles from './styles';
 
 type RootStackParamList = {
   SortationPutawayLocationScan: {
-    taskList: SortationTask[];
     currentTaskIndex: number;
     isUserDirected?: boolean;
     containerId?: string;
   };
   SortationPutawayTaskList: {
     containerId: string;
-    taskList: SortationTask[];
   };
 };
 
@@ -27,7 +27,6 @@ type PutawayModeScreenProps = {
   route: {
     params: {
       containerId: string;
-      taskList: SortationTask[];
     };
   };
 };
@@ -53,27 +52,27 @@ function ModeCard({
         <Text style={styles.modeCardDescription}>{description}</Text>
       </View>
       <View style={styles.modeCardRight} focusable={false}>
-        <Icon name={7} />
+        <Icon name={Name.ChevronRight} />
       </View>
     </TouchableOpacity>
   );
 }
 
 export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
-  const { containerId, taskList } = route.params;
+  const { containerId } = route.params;
   const navigation = useNavigation<NavigationProp>();
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
 
   const taskSummary = useMemo(() => {
-    const zones = new Set(taskList.map((task) => task.destination?.zoneName).filter(Boolean));
+    const zones = new Set(putawayTasks?.map((task) => task.destination?.zoneName).filter(Boolean) || []);
     return {
-      totalItems: taskList.length,
+      totalItems: putawayTasks?.length || 0,
       totalZones: zones.size
     };
-  }, [taskList]);
+  }, [putawayTasks]);
 
   const handleSystemDirected = () => {
     navigation.navigate('SortationPutawayLocationScan', {
-      taskList,
       currentTaskIndex: 0,
       isUserDirected: false,
       containerId
@@ -82,8 +81,7 @@ export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
 
   const handleUserDirected = () => {
     navigation.navigate('SortationPutawayTaskList', {
-      containerId,
-      taskList
+      containerId
     });
   };
 

--- a/src/screens/SortationPutaway/PutawayModeScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayModeScreen.tsx
@@ -97,11 +97,7 @@ export default function PutawayModeScreen({ route }: PutawayModeScreenProps) {
             Container Id: <Text style={styles.bold}>{containerId}</Text>
           </Chip>
           <Chip icon="package" style={styles.chipDefault} textStyle={styles.chipText}>
-            Tasks:{' '}
-            <Text style={styles.bold}>
-              {taskSummary.totalItems} item{taskSummary.totalItems !== 1 ? 's' : ''} across {taskSummary.totalZones}{' '}
-              zone{taskSummary.totalZones !== 1 ? 's' : ''}
-            </Text>
+            Tasks: <Text style={styles.bold}>{taskSummary.totalItems}</Text>
           </Chip>
         </View>
       </View>

--- a/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
@@ -23,7 +23,7 @@ type PutawayProductScanRouteProp = RouteProp<
 
 export default function PutawayProductScanScreen() {
   const { params } = useRoute<PutawayProductScanRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway } = params;
+  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
   const putawayDetails = taskList[currentTaskIndex];
   const [putawayProductBarcode, setPutawayProductBarcode] = useState<string>(EMPTY_STRING);
 
@@ -46,7 +46,6 @@ export default function PutawayProductScanScreen() {
       Alert.alert(
         'Wrong Product',
         `The scanned barcode does not match the expected putaway product (${product?.productCode}).`,
-        // Clear input on error to allow retry
         [{ text: 'OK', onPress: () => setPutawayProductBarcode(EMPTY_STRING) }]
       );
       return;
@@ -55,7 +54,9 @@ export default function PutawayProductScanScreen() {
     navigate('SortationPutawayQuantity', {
       taskList,
       currentTaskIndex,
-      isDirectPutaway
+      isDirectPutaway,
+      isUserDirected,
+      containerId
     });
   }
 
@@ -65,7 +66,12 @@ export default function PutawayProductScanScreen() {
       style={styles.contentWrapper}
       contentContainerStyle={styles.contentContainer}
     >
-      <PutawayDetails putawayDetails={putawayDetails} />
+      <PutawayDetails
+        putawayDetails={putawayDetails}
+        taskIndex={currentTaskIndex}
+        totalTasks={taskList.length}
+        showTaskCounter={!isUserDirected}
+      />
 
       <Divider />
 
@@ -82,15 +88,15 @@ export default function PutawayProductScanScreen() {
 
         <Button
           style={styles.topSpace}
-          title="Confirm"
+          title="Submit"
           mode="contained"
           size="100%"
           onPress={() => handleProcessing(putawayProductBarcode)}
-        >
-          Submit
-        </Button>
+        />
 
-        <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+        {!isUserDirected && (
+          <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+        )}
       </View>
     </ScrollView>
   );

--- a/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
@@ -2,13 +2,15 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import React, { useState } from 'react';
 import { Alert, ScrollView, View } from 'react-native';
 import { Divider, Subheading } from 'react-native-paper';
+import { useSelector } from 'react-redux';
 
 import Button from '../../components/Button';
 import EmptyView from '../../components/EmptyView';
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
 import { navigate } from '../../NavigationService';
-import { SortationPutawayScreenType } from '../../types/sortation';
+import { RootState } from '../../redux/reducers';
+import { SortationTask } from '../../types/sortation';
 import { isProductBarcodeValid } from '../../utils/utils';
 import PutawayDetails from './PutawayDetails';
 import { SkipButton } from './SkipButton';
@@ -16,15 +18,21 @@ import styles from './styles';
 
 type PutawayProductScanRouteProp = RouteProp<
   {
-    SortationPutawayProductScan: SortationPutawayScreenType;
+    SortationPutawayProductScan: {
+      currentTaskIndex: number;
+      isDirectPutaway?: boolean;
+      isUserDirected?: boolean;
+      containerId?: string;
+    };
   },
   'SortationPutawayProductScan'
 >;
 
 export default function PutawayProductScanScreen() {
   const { params } = useRoute<PutawayProductScanRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
-  const putawayDetails = taskList[currentTaskIndex];
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
+  const putawayDetails = putawayTasks?.[currentTaskIndex];
   const [putawayProductBarcode, setPutawayProductBarcode] = useState<string>(EMPTY_STRING);
 
   if (!putawayDetails) {
@@ -52,7 +60,6 @@ export default function PutawayProductScanScreen() {
     }
 
     navigate('SortationPutawayQuantity', {
-      taskList,
       currentTaskIndex,
       isDirectPutaway,
       isUserDirected,
@@ -69,7 +76,7 @@ export default function PutawayProductScanScreen() {
       <PutawayDetails
         putawayDetails={putawayDetails}
         taskIndex={currentTaskIndex}
-        totalTasks={taskList.length}
+        totalTasks={putawayTasks.length}
         showTaskCounter={!isUserDirected}
       />
 
@@ -95,7 +102,7 @@ export default function PutawayProductScanScreen() {
         />
 
         {!isUserDirected && (
-          <SkipButton taskList={taskList} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+          <SkipButton taskList={putawayTasks} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
         )}
       </View>
     </ScrollView>

--- a/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
@@ -102,7 +102,12 @@ export default function PutawayProductScanScreen() {
         />
 
         {!isUserDirected && (
-          <SkipButton taskList={putawayTasks} currentTaskIndex={currentTaskIndex} isDirectPutaway={isDirectPutaway} />
+          <SkipButton
+            taskList={putawayTasks}
+            currentTaskIndex={currentTaskIndex}
+            isDirectPutaway={isDirectPutaway}
+            containerId={containerId}
+          />
         )}
       </View>
     </ScrollView>

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -2,7 +2,7 @@ import { RouteProp, useIsFocused, useRoute } from '@react-navigation/native';
 import React, { useEffect, useRef, useState } from 'react';
 import { Alert, ScrollView, TextInput, View } from 'react-native';
 import { Divider, TextInput as PaperTextInput, Paragraph, Portal, Subheading, Switch } from 'react-native-paper';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import AsyncModalSelect from '../../components/AsyncModalSelect';
 import Button from '../../components/Button';
@@ -11,7 +11,8 @@ import { INPUT_FOCUS_DELAY_TIME_IN_MS } from '../../constants';
 import { navigate, replace } from '../../NavigationService';
 import { getReasonCodesAction } from '../../redux/actions/others';
 import { patchPutawayTaskAction } from '../../redux/actions/putaways';
-import { PutawayDetailsModel, SortationLocation } from '../../types/sortation';
+import { RootState } from '../../redux/reducers';
+import { SortationLocation, SortationTask } from '../../types/sortation';
 import Theme from '../../utils/Theme';
 import AlternativeLocationSelector from './AlternativeLocationSelector';
 import PutawayDetails from './PutawayDetails';
@@ -20,7 +21,6 @@ import styles from './styles';
 type PutawayQuantityRouteProp = RouteProp<
   {
     SortationPutawayQuantity: {
-      taskList: PutawayDetailsModel[];
       currentTaskIndex: number;
       isDirectPutaway?: boolean;
       isUserDirected?: boolean;
@@ -37,8 +37,9 @@ type ReasonCode = {
 
 export default function PutawayQuantityScreen() {
   const { params } = useRoute<PutawayQuantityRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
-  const putawayDetails = taskList[currentTaskIndex];
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
+  const putawayDetails = putawayTasks?.[currentTaskIndex];
   const dispatch = useDispatch();
 
   const inputRef = useRef<TextInput | null>(null);
@@ -46,7 +47,7 @@ export default function PutawayQuantityScreen() {
 
   const [putawayQuantity, setPutawayQuantity] = useState<number | undefined>();
   const [selectedAlternativeDestination, setSelectedAlternativeDestination] = useState<SortationLocation | null>(
-    putawayDetails.destination
+    putawayDetails?.destination
   );
   const [reasonCodes, setReasonCodes] = useState<ReasonCode[]>([]);
   const [selectedReasonCode, setSelectedReasonCode] = useState<ReasonCode | null>(null);
@@ -168,7 +169,6 @@ export default function PutawayQuantityScreen() {
         } else {
           // Cancel Remaining False - Navigate to Quantity Screen with new task
           replace('SortationPutawayQuantity', {
-            taskList: [remainingTask],
             currentTaskIndex: 0,
             isDirectPutaway,
             isUserDirected,
@@ -193,9 +193,8 @@ export default function PutawayQuantityScreen() {
         navigate('SortationPutawayTaskList', { containerId });
       } else {
         const nextIndex = currentTaskIndex + 1;
-        if (nextIndex < taskList.length) {
+        if (nextIndex < putawayTasks?.length) {
           navigate('SortationPutawayLocationScan', {
-            taskList,
             currentTaskIndex: nextIndex,
             isDirectPutaway,
             isUserDirected,
@@ -223,7 +222,7 @@ export default function PutawayQuantityScreen() {
         <PutawayDetails
           putawayDetails={updatedPutawayDetails}
           taskIndex={currentTaskIndex}
-          totalTasks={taskList.length}
+          totalTasks={putawayTasks?.length || 0}
           showTaskCounter={!isUserDirected}
         />
         <Divider />

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -19,7 +19,13 @@ import styles from './styles';
 
 type PutawayQuantityRouteProp = RouteProp<
   {
-    SortationPutawayQuantity: { taskList: PutawayDetailsModel[]; currentTaskIndex: number; isDirectPutaway?: boolean };
+    SortationPutawayQuantity: {
+      taskList: PutawayDetailsModel[];
+      currentTaskIndex: number;
+      isDirectPutaway?: boolean;
+      isUserDirected?: boolean;
+      containerId?: string;
+    };
   },
   'SortationPutawayQuantity'
 >;
@@ -31,7 +37,7 @@ type ReasonCode = {
 
 export default function PutawayQuantityScreen() {
   const { params } = useRoute<PutawayQuantityRouteProp>();
-  const { taskList, currentTaskIndex, isDirectPutaway } = params;
+  const { taskList, currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
   const putawayDetails = taskList[currentTaskIndex];
   const dispatch = useDispatch();
 
@@ -164,7 +170,9 @@ export default function PutawayQuantityScreen() {
           replace('SortationPutawayQuantity', {
             taskList: [remainingTask],
             currentTaskIndex: 0,
-            isDirectPutaway
+            isDirectPutaway,
+            isUserDirected,
+            containerId
           });
         }
       })
@@ -180,15 +188,22 @@ export default function PutawayQuantityScreen() {
   function handleResponseAfterComplete(response: any) {
     if (response && !response.error) {
       Alert.alert('Putaway Successful', 'The putaway was successful.');
-      const nextIndex = currentTaskIndex + 1;
-      if (nextIndex < taskList.length) {
-        navigate('SortationPutawayLocationScan', {
-          taskList,
-          currentTaskIndex: nextIndex,
-          isDirectPutaway
-        });
+
+      if (isUserDirected && containerId) {
+        navigate('SortationPutawayTaskList', { containerId });
       } else {
-        navigate(isDirectPutaway ? 'Sortation' : 'SortationPutaway');
+        const nextIndex = currentTaskIndex + 1;
+        if (nextIndex < taskList.length) {
+          navigate('SortationPutawayLocationScan', {
+            taskList,
+            currentTaskIndex: nextIndex,
+            isDirectPutaway,
+            isUserDirected,
+            containerId
+          });
+        } else {
+          navigate(isDirectPutaway ? 'Sortation' : 'SortationPutaway');
+        }
       }
     } else {
       Alert.alert('Putaway Failed', response?.errorMessage || 'Putaway failed.');
@@ -205,7 +220,12 @@ export default function PutawayQuantityScreen() {
   return (
     <Portal.Host>
       <ScrollView keyboardShouldPersistTaps="handled" style={styles.contentContainer}>
-        <PutawayDetails putawayDetails={updatedPutawayDetails} />
+        <PutawayDetails
+          putawayDetails={updatedPutawayDetails}
+          taskIndex={currentTaskIndex}
+          totalTasks={taskList.length}
+          showTaskCounter={!isUserDirected}
+        />
         <Divider />
 
         <View style={styles.formContainer}>
@@ -256,9 +276,7 @@ export default function PutawayQuantityScreen() {
         </View>
 
         <View style={styles.bottomActionContainer}>
-          <Button style={styles.topSpace} title="Confirm" mode="contained" size="100%" onPress={handleConfirm}>
-            Submit
-          </Button>
+          <Button style={styles.topSpace} title="Submit" mode="contained" size="100%" onPress={handleConfirm} />
         </View>
       </ScrollView>
 

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -101,7 +101,7 @@ export default function PutawayQuantityScreen() {
   }
 
   function handleConfirm() {
-    const totalQty = putawayDetails.quantity;
+    const totalQty = Number(putawayDetails.quantity);
 
     if (putawayQuantity === undefined || putawayQuantity < 0 || putawayQuantity > putawayDetails.quantity) {
       Alert.alert(
@@ -222,7 +222,7 @@ export default function PutawayQuantityScreen() {
 
   return (
     <Portal.Host>
-      <ScrollView keyboardShouldPersistTaps="handled" style={styles.contentContainer}>
+      <ScrollView keyboardShouldPersistTaps="always" style={styles.contentContainer}>
         <PutawayDetails
           putawayDetails={updatedPutawayDetails}
           taskIndex={currentTaskIndex}

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -10,7 +10,7 @@ import EmptyView from '../../components/EmptyView';
 import { INPUT_FOCUS_DELAY_TIME_IN_MS } from '../../constants';
 import { navigate, replace } from '../../NavigationService';
 import { getReasonCodesAction } from '../../redux/actions/others';
-import { patchPutawayTaskAction } from '../../redux/actions/putaways';
+import { getPutawayDetailsByContainerId, patchPutawayTaskAction } from '../../redux/actions/putaways';
 import { RootState } from '../../redux/reducers';
 import { SortationLocation, SortationTask } from '../../types/sortation';
 import Theme from '../../utils/Theme';
@@ -168,6 +168,7 @@ export default function PutawayQuantityScreen() {
           );
         } else {
           // Cancel Remaining False - Navigate to Quantity Screen with new task
+          dispatch(getPutawayDetailsByContainerId(containerId!, () => {}));
           replace('SortationPutawayQuantity', {
             currentTaskIndex: 0,
             isDirectPutaway,
@@ -192,10 +193,13 @@ export default function PutawayQuantityScreen() {
       if (isUserDirected && containerId) {
         navigate('SortationPutawayTaskList', { containerId });
       } else {
-        const nextIndex = currentTaskIndex + 1;
-        if (nextIndex < putawayTasks?.length) {
+        // Re-fetch removes the completed task, so remaining tasks shift down.
+        // Use index 0 to start at the new first task after re-fetch.
+        const hasMoreTasks = putawayTasks?.length > 1;
+        if (hasMoreTasks) {
+          dispatch(getPutawayDetailsByContainerId(containerId!));
           navigate('SortationPutawayLocationScan', {
-            currentTaskIndex: nextIndex,
+            currentTaskIndex: 0,
             isDirectPutaway,
             isUserDirected,
             containerId

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -77,7 +77,6 @@ type PutawayTaskListScreenProps = {
   route: {
     params: {
       containerId: string;
-      taskList?: SortationTask[];
     };
   };
 };

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,12 +1,13 @@
-import { useNavigation } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Button, Chip, Divider, Paragraph } from 'react-native-paper';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import Icon, { Name } from '../../components/Icon';
 import { ScannerInput } from '../../components/ScannerInput';
+import { getPutawayDetailsByContainerId } from '../../redux/actions/putaways';
 import { RootState } from '../../redux/reducers';
 import { SortationTask } from '../../types/sortation';
 import styles from './styles';
@@ -84,9 +85,20 @@ type PutawayTaskListScreenProps = {
 export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenProps) {
   const { containerId } = route.params;
   const navigation = useNavigation<NavigationProp>();
+  const dispatch = useDispatch();
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
   const [searchTerm, setSearchTerm] = useState('');
   const [expandedZones, setExpandedZones] = useState<{ [key: string]: boolean }>({});
+
+  const fetchTasks = useCallback(() => {
+    dispatch(getPutawayDetailsByContainerId(containerId));
+  }, [dispatch, containerId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchTasks();
+    }, [fetchTasks])
+  );
 
   const filteredTasks = useMemo(() => {
     if (!putawayTasks) {
@@ -124,14 +136,16 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
 
   useEffect(() => {
     if (searchTerm.trim() && filteredTasks.length === 1) {
+      const matchedTask = filteredTasks[0];
+      const globalIndex = putawayTasks.findIndex((t) => t.id === matchedTask.id);
       setSearchTerm('');
       navigation.navigate('SortationPutawayLocationScan', {
-        currentTaskIndex: 0,
+        currentTaskIndex: globalIndex >= 0 ? globalIndex : 0,
         isUserDirected: true,
         containerId
       });
     }
-  }, [searchTerm, filteredTasks, navigation, containerId]);
+  }, [searchTerm, filteredTasks, putawayTasks, navigation, containerId]);
 
   const isSearching = searchTerm.trim().length > 0;
 
@@ -145,7 +159,7 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
   const toggleZone = (zoneName: string) => {
     setExpandedZones((prev) => ({
       ...prev,
-      [zoneName]: !prev[zoneName]
+      [zoneName]: !(prev[zoneName] ?? true)
     }));
   };
 
@@ -155,10 +169,13 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
       return;
     }
 
+    const selectedTask = zoneTasks.tasks[taskIndex];
+    const globalIndex = putawayTasks.findIndex((t) => t.id === selectedTask.id);
+
     setSearchTerm('');
 
     navigation.navigate('SortationPutawayLocationScan', {
-      currentTaskIndex: filteredTasks.findIndex((t) => t.id === zoneTasks.tasks[taskIndex].id),
+      currentTaskIndex: globalIndex >= 0 ? globalIndex : 0,
       isUserDirected: true,
       containerId
     });

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,9 +1,76 @@
-import React from 'react';
-import { ScrollView } from 'react-native';
-import { Paragraph, Title } from 'react-native-paper';
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import React, { useMemo, useState } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Button, Chip, Divider, Paragraph } from 'react-native-paper';
 
+import Icon, { Name } from '../../components/Icon';
+import { ScannerInput } from '../../components/ScannerInput';
 import { SortationTask } from '../../types/sortation';
 import styles from './styles';
+
+type RootStackParamList = {
+  SortationPutawayLocationScan: {
+    taskList: SortationTask[];
+    currentTaskIndex: number;
+    isUserDirected?: boolean;
+    containerId?: string;
+  };
+  SortationPutawayTaskList: {
+    containerId: string;
+    taskList: SortationTask[];
+  };
+};
+
+type NavigationProp = StackNavigationProp<RootStackParamList, any>;
+
+type TaskRowProps = {
+  task: SortationTask;
+  onPress: () => void;
+};
+
+function TaskRow({ task, onPress }: TaskRowProps) {
+  const productCode = task.inventoryItem?.product?.productCode || '-';
+  const location = task.destination?.locationNumber || '-';
+  const quantity = task.quantity || 0;
+
+  return (
+    <TouchableOpacity style={styles.taskRow} activeOpacity={0.7} onPress={onPress}>
+      <View style={styles.taskRowContent}>
+        <Text style={styles.taskRowProduct}>{productCode}</Text>
+        <Text style={styles.taskRowLocation}>{location}</Text>
+        <Text style={styles.taskRowQuantity}>{quantity}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+type ZoneSectionProps = {
+  zoneName: string;
+  tasks: SortationTask[];
+  onTaskPress: (index: number) => void;
+  isExpanded: boolean;
+  onToggle: () => void;
+  taskCount: number;
+};
+
+function ZoneSection({ zoneName, tasks, onTaskPress, isExpanded, onToggle, taskCount }: ZoneSectionProps) {
+  return (
+    <View style={styles.zoneSection}>
+      <TouchableOpacity style={styles.zoneHeader} activeOpacity={0.7} onPress={onToggle}>
+        <View style={styles.zoneHeaderContent}>
+          <Text style={styles.zoneHeaderLabel}>Zone:</Text>
+          <Text style={styles.zoneHeaderText}>
+            {zoneName || 'Not Defined'} ({taskCount} Task{taskCount !== 1 ? 's' : ''})
+          </Text>
+        </View>
+        <Icon name={isExpanded ? Name.ChevronUp : Name.ChevronDown} size={18} style={styles.zoneHeaderIcon} />
+      </TouchableOpacity>
+      {isExpanded &&
+        tasks.map((task, index) => <TaskRow key={task.id} task={task} onPress={() => onTaskPress(index)} />)}
+    </View>
+  );
+}
 
 type PutawayTaskListScreenProps = {
   route: {
@@ -15,14 +82,131 @@ type PutawayTaskListScreenProps = {
 };
 
 export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenProps) {
-  const { containerId, taskList } = route.params;
+  const { containerId, taskList: initialTaskList = [] } = route.params;
+  const navigation = useNavigation<NavigationProp>();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [expandedZones, setExpandedZones] = useState<{ [key: string]: boolean }>({});
+
+  const filteredTasks = useMemo(() => {
+    if (!initialTaskList) {
+      return [];
+    }
+    if (!searchTerm.trim()) {
+      return initialTaskList;
+    }
+    const term = searchTerm.toLowerCase().trim();
+    return initialTaskList.filter((task) => {
+      const productCode = task.inventoryItem?.product?.productCode?.toLowerCase() || '';
+      return productCode.includes(term);
+    });
+  }, [initialTaskList, searchTerm]);
+
+  const groupedTasks = useMemo(() => {
+    if (!filteredTasks) {
+      return [];
+    }
+    const groups: { [key: string]: SortationTask[] } = {};
+
+    filteredTasks.forEach((task) => {
+      const zoneName = task.destination?.zoneName || 'Not Defined';
+      if (!groups[zoneName]) {
+        groups[zoneName] = [];
+      }
+      groups[zoneName].push(task);
+    });
+
+    return Object.entries(groups).map(([zoneName, tasks]) => ({
+      zoneName,
+      tasks
+    }));
+  }, [filteredTasks]);
+
+  const isSearching = searchTerm.trim().length > 0;
+
+  const isZoneExpanded = (zoneName: string) => {
+    if (isSearching) {
+      return true;
+    }
+    return expandedZones[zoneName] ?? true;
+  };
+
+  const toggleZone = (zoneName: string) => {
+    setExpandedZones((prev) => ({
+      ...prev,
+      [zoneName]: !prev[zoneName]
+    }));
+  };
+
+  const handleTaskPress = (zoneName: string, taskIndex: number) => {
+    const zoneTasks = groupedTasks.find((g) => g.zoneName === zoneName);
+    if (!zoneTasks) {
+      return;
+    }
+
+    navigation.navigate('SortationPutawayLocationScan', {
+      taskList: filteredTasks,
+      currentTaskIndex: filteredTasks.findIndex((t) => t.id === zoneTasks.tasks[taskIndex].id),
+      isUserDirected: true,
+      containerId
+    });
+  };
+
+  const handleClearSearch = () => {
+    setSearchTerm('');
+  };
 
   return (
-    <ScrollView keyboardShouldPersistTaps="always" style={styles.screen}>
-      <Title style={styles.topSpace}>Container: {containerId}</Title>
-      <Paragraph style={styles.paragraph}>
-        {taskList.length} task{taskList.length !== 1 ? 's' : ''} available
-      </Paragraph>
+    <ScrollView
+      keyboardShouldPersistTaps="always"
+      style={styles.contentWrapper}
+      contentContainerStyle={styles.contentContainer}
+    >
+      <View style={styles.productDetails}>
+        <View style={styles.headerRow}>
+          <Chip icon="identifier" style={styles.chipDefault} textStyle={styles.chipText}>
+            Container: <Text style={styles.bold}>{containerId}</Text>
+          </Chip>
+        </View>
+        <ScannerInput
+          value={searchTerm}
+          label="Product"
+          style={styles.topSpace}
+          onChange={setSearchTerm}
+          onSubmit={setSearchTerm}
+        />
+        {searchTerm.length > 0 && (
+          <Button mode="contained" style={styles.clearButton} onPress={handleClearSearch}>
+            Clear
+          </Button>
+        )}
+      </View>
+
+      <Divider />
+
+      <View style={styles.formContainer}>
+        <View style={styles.tableHeader}>
+          <Text style={[styles.tableHeaderText, styles.tableHeaderProduct]}>Product</Text>
+          <Text style={[styles.tableHeaderText, styles.tableHeaderLocation]}>Putaway Location</Text>
+          <Text style={[styles.tableHeaderText, styles.tableHeaderQty]}>Quantity</Text>
+        </View>
+        {groupedTasks.length === 0 ? (
+          <View style={styles.emptyTableContent}>
+            <Paragraph style={styles.emptyText}>No tasks found</Paragraph>
+          </View>
+        ) : (
+          groupedTasks.map((group) => (
+            <ZoneSection
+              key={group.zoneName}
+              zoneName={group.zoneName}
+              tasks={group.tasks}
+              taskCount={group.tasks.length}
+              isExpanded={isZoneExpanded(group.zoneName)}
+              onToggle={() => toggleZone(group.zoneName)}
+              onTaskPress={(taskIndex) => handleTaskPress(group.zoneName, taskIndex)}
+            />
+          ))
+        )}
+      </View>
     </ScrollView>
   );
 }

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ScrollView } from 'react-native';
+import { Paragraph, Title } from 'react-native-paper';
+
+import { SortationTask } from '../../types/sortation';
+import styles from './styles';
+
+type PutawayTaskListScreenProps = {
+  route: {
+    params: {
+      containerId: string;
+      taskList: SortationTask[];
+    };
+  };
+};
+
+export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenProps) {
+  const { containerId, taskList } = route.params;
+
+  return (
+    <ScrollView keyboardShouldPersistTaps="always" style={styles.screen}>
+      <Title style={styles.topSpace}>Container: {containerId}</Title>
+      <Paragraph style={styles.paragraph}>
+        {taskList.length} task{taskList.length !== 1 ? 's' : ''} available
+      </Paragraph>
+    </ScrollView>
+  );
+}

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,24 +1,24 @@
 import { useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Button, Chip, Divider, Paragraph } from 'react-native-paper';
+import { useSelector } from 'react-redux';
 
 import Icon, { Name } from '../../components/Icon';
 import { ScannerInput } from '../../components/ScannerInput';
+import { RootState } from '../../redux/reducers';
 import { SortationTask } from '../../types/sortation';
 import styles from './styles';
 
 type RootStackParamList = {
   SortationPutawayLocationScan: {
-    taskList: SortationTask[];
     currentTaskIndex: number;
     isUserDirected?: boolean;
     containerId?: string;
   };
   SortationPutawayTaskList: {
     containerId: string;
-    taskList: SortationTask[];
   };
 };
 
@@ -59,7 +59,7 @@ function ZoneSection({ zoneName, tasks, onTaskPress, isExpanded, onToggle, taskC
     <View style={styles.zoneSection}>
       <TouchableOpacity style={styles.zoneHeader} activeOpacity={0.7} onPress={onToggle}>
         <View style={styles.zoneHeaderContent}>
-          <Text style={styles.zoneHeaderLabel}>Zone:</Text>
+          <Text style={styles.zoneHeaderLabel}>Zone</Text>
           <Text style={styles.zoneHeaderText}>
             {zoneName || 'Not Defined'} ({taskCount} Task{taskCount !== 1 ? 's' : ''})
           </Text>
@@ -76,30 +76,31 @@ type PutawayTaskListScreenProps = {
   route: {
     params: {
       containerId: string;
-      taskList: SortationTask[];
+      taskList?: SortationTask[];
     };
   };
 };
 
 export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenProps) {
-  const { containerId, taskList: initialTaskList = [] } = route.params;
+  const { containerId } = route.params;
   const navigation = useNavigation<NavigationProp>();
+  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
   const [searchTerm, setSearchTerm] = useState('');
   const [expandedZones, setExpandedZones] = useState<{ [key: string]: boolean }>({});
 
   const filteredTasks = useMemo(() => {
-    if (!initialTaskList) {
+    if (!putawayTasks) {
       return [];
     }
     if (!searchTerm.trim()) {
-      return initialTaskList;
+      return putawayTasks;
     }
     const term = searchTerm.toLowerCase().trim();
-    return initialTaskList.filter((task) => {
+    return putawayTasks.filter((task) => {
       const productCode = task.inventoryItem?.product?.productCode?.toLowerCase() || '';
       return productCode.includes(term);
     });
-  }, [initialTaskList, searchTerm]);
+  }, [searchTerm, putawayTasks]);
 
   const groupedTasks = useMemo(() => {
     if (!filteredTasks) {
@@ -120,6 +121,17 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
       tasks
     }));
   }, [filteredTasks]);
+
+  useEffect(() => {
+    if (searchTerm.trim() && filteredTasks.length === 1) {
+      setSearchTerm('');
+      navigation.navigate('SortationPutawayLocationScan', {
+        currentTaskIndex: 0,
+        isUserDirected: true,
+        containerId
+      });
+    }
+  }, [searchTerm, filteredTasks, navigation, containerId]);
 
   const isSearching = searchTerm.trim().length > 0;
 
@@ -143,8 +155,9 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
       return;
     }
 
+    setSearchTerm('');
+
     navigation.navigate('SortationPutawayLocationScan', {
-      taskList: filteredTasks,
       currentTaskIndex: filteredTasks.findIndex((t) => t.id === zoneTasks.tasks[taskIndex].id),
       isUserDirected: true,
       containerId

--- a/src/screens/SortationPutaway/SkipButton.tsx
+++ b/src/screens/SortationPutaway/SkipButton.tsx
@@ -3,10 +3,16 @@ import { Alert } from 'react-native';
 
 import Button from '../../components/Button';
 import { navigate } from '../../NavigationService';
-import { SortationPutawayScreenType } from '../../types/sortation';
+import { SortationTask } from '../../types/sortation';
 import styles from './styles';
 
-export function SkipButton({ taskList, currentTaskIndex, isDirectPutaway = false }: SortationPutawayScreenType) {
+type SkipButtonProps = {
+  taskList: SortationTask[];
+  currentTaskIndex: number;
+  isDirectPutaway?: boolean;
+};
+
+export function SkipButton({ taskList, currentTaskIndex, isDirectPutaway = false }: SkipButtonProps) {
   function handleSkip() {
     Alert.alert(
       'Skip Putaway',

--- a/src/screens/SortationPutaway/SkipButton.tsx
+++ b/src/screens/SortationPutaway/SkipButton.tsx
@@ -10,9 +10,10 @@ type SkipButtonProps = {
   taskList: SortationTask[];
   currentTaskIndex: number;
   isDirectPutaway?: boolean;
+  containerId?: string;
 };
 
-export function SkipButton({ taskList, currentTaskIndex, isDirectPutaway = false }: SkipButtonProps) {
+export function SkipButton({ taskList, currentTaskIndex, isDirectPutaway = false, containerId }: SkipButtonProps) {
   function handleSkip() {
     Alert.alert(
       'Skip Putaway',
@@ -27,9 +28,9 @@ export function SkipButton({ taskList, currentTaskIndex, isDirectPutaway = false
             const currentIndex = nextIndex < taskList.length ? nextIndex : 0;
 
             navigate('SortationPutawayLocationScan', {
-              taskList,
               currentTaskIndex: currentIndex,
-              isDirectPutaway
+              isDirectPutaway,
+              containerId
             });
           }
         }

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -253,9 +253,14 @@ export default StyleSheet.create({
     marginTop: Theme.spacing.large
   },
   zoneHeader: {
-    backgroundColor: '#F5F5F5',
-    paddingVertical: Theme.spacing.small,
-    paddingHorizontal: Theme.spacing.large
+    backgroundColor: '#E8EDF2',
+    paddingVertical: Theme.spacing.medium,
+    paddingHorizontal: Theme.spacing.large,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderBottomColor: '#D0D0D0'
   },
   zoneHeaderText: {
     fontSize: 14,
@@ -288,50 +293,6 @@ export default StyleSheet.create({
     flex: 1,
     textAlign: 'right'
   },
-  taskRow: {
-    backgroundColor: '#FFFFFF',
-    paddingVertical: Theme.spacing.large,
-    paddingHorizontal: Theme.spacing.large,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E0E0E0',
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  taskRowContent: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center'
-  },
-  taskRowProduct: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: Theme.colors.primary,
-    flex: 1
-  },
-  taskRowLocation: {
-    fontSize: 14,
-    color: Theme.colors.text,
-    flex: 1,
-    textAlign: 'center'
-  },
-  taskRowQuantity: {
-    fontSize: 14,
-    fontWeight: 'bold',
-    color: Theme.colors.text,
-    flex: 1,
-    textAlign: 'right'
-  },
-  zoneSection: {
-    marginTop: Theme.spacing.small
-  },
-  zoneHeader: {
-    backgroundColor: '#E8EDF2',
-    paddingVertical: Theme.spacing.medium,
-    paddingHorizontal: Theme.spacing.large,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center'
-  },
   zoneHeaderContent: {
     flexDirection: 'column'
   },
@@ -340,11 +301,6 @@ export default StyleSheet.create({
     fontWeight: '500',
     color: '#666666',
     marginBottom: 2
-  },
-  zoneHeaderText: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#333333'
   },
   zoneHeaderIcon: {
     color: '#666666'

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -48,6 +48,13 @@ export default StyleSheet.create({
     alignItems: 'center',
     backgroundColor: Theme.colors.warning
   },
+  chipInfo: {
+    height: 28,
+    justifyContent: 'flex-start',
+    borderRadius: 4,
+    alignItems: 'center',
+    backgroundColor: Theme.colors.primary
+  },
   contentDivider: {
     marginVertical: 8
   },
@@ -211,5 +218,151 @@ export default StyleSheet.create({
   modeDescription: {
     color: Theme.colors.text,
     marginTop: 4
+  },
+  taskRow: {
+    backgroundColor: '#FFFFFF',
+    padding: Theme.spacing.large,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0'
+  },
+  taskRowContent: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  taskRowProduct: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Theme.colors.primary,
+    flex: 2
+  },
+  taskRowLocation: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    flex: 1,
+    textAlign: 'center'
+  },
+  taskRowQuantity: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: Theme.colors.text,
+    flex: 0.5,
+    textAlign: 'right'
+  },
+  zoneSection: {
+    marginTop: Theme.spacing.large
+  },
+  zoneHeader: {
+    backgroundColor: '#F5F5F5',
+    paddingVertical: Theme.spacing.small,
+    paddingHorizontal: Theme.spacing.large
+  },
+  zoneHeaderText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: Theme.colors.text
+  },
+  clearButton: {
+    marginTop: Theme.spacing.medium
+  },
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: Theme.colors.primary,
+    paddingVertical: Theme.spacing.large,
+    paddingHorizontal: Theme.spacing.large,
+    alignItems: 'center'
+  },
+  tableHeaderText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#FFFFFF'
+  },
+  tableHeaderProduct: {
+    flex: 1
+  },
+  tableHeaderLocation: {
+    flex: 1,
+    textAlign: 'center'
+  },
+  tableHeaderQty: {
+    flex: 1,
+    textAlign: 'right'
+  },
+  taskRow: {
+    backgroundColor: '#FFFFFF',
+    paddingVertical: Theme.spacing.large,
+    paddingHorizontal: Theme.spacing.large,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0',
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  taskRowContent: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  taskRowProduct: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Theme.colors.primary,
+    flex: 1
+  },
+  taskRowLocation: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    flex: 1,
+    textAlign: 'center'
+  },
+  taskRowQuantity: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: Theme.colors.text,
+    flex: 1,
+    textAlign: 'right'
+  },
+  zoneSection: {
+    marginTop: Theme.spacing.small
+  },
+  zoneHeader: {
+    backgroundColor: '#E8EDF2',
+    paddingVertical: Theme.spacing.medium,
+    paddingHorizontal: Theme.spacing.large,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  zoneHeaderContent: {
+    flexDirection: 'column'
+  },
+  zoneHeaderLabel: {
+    fontSize: 11,
+    fontWeight: '500',
+    color: '#666666',
+    marginBottom: 2
+  },
+  zoneHeaderText: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#333333'
+  },
+  zoneHeaderIcon: {
+    color: '#666666'
+  },
+  emptyTableContent: {
+    paddingVertical: Theme.spacing.large * 2,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  emptyText: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    textAlign: 'center'
+  },
+  resultsCount: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    marginTop: Theme.spacing.medium,
+    textAlign: 'center'
   }
 });

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -48,13 +48,6 @@ export default StyleSheet.create({
     alignItems: 'center',
     backgroundColor: Theme.colors.warning
   },
-  chipInfo: {
-    height: 28,
-    justifyContent: 'flex-start',
-    borderRadius: 4,
-    alignItems: 'center',
-    backgroundColor: Theme.colors.primary
-  },
   contentDivider: {
     marginVertical: 8
   },
@@ -166,10 +159,6 @@ export default StyleSheet.create({
   dialogActionButton: {
     marginLeft: Theme.spacing.small
   },
-  modeCard: {
-    marginTop: Theme.spacing.large,
-    backgroundColor: Theme.colors.surface
-  },
   modeCardContainer: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -204,18 +193,6 @@ export default StyleSheet.create({
   },
   modeCardDescription: {
     fontSize: 14,
-    color: Theme.colors.text,
-    marginTop: 4
-  },
-  modeCardChevron: {
-    fontSize: 24,
-    color: '#888888'
-  },
-  modeTitle: {
-    fontWeight: 'bold',
-    color: Theme.colors.primary
-  },
-  modeDescription: {
     color: Theme.colors.text,
     marginTop: 4
   },
@@ -313,12 +290,6 @@ export default StyleSheet.create({
   emptyText: {
     fontSize: 14,
     color: Theme.colors.text,
-    textAlign: 'center'
-  },
-  resultsCount: {
-    fontSize: 14,
-    color: Theme.colors.text,
-    marginTop: Theme.spacing.medium,
     textAlign: 'center'
   }
 });

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -158,5 +158,58 @@ export default StyleSheet.create({
   },
   dialogActionButton: {
     marginLeft: Theme.spacing.small
+  },
+  modeCard: {
+    marginTop: Theme.spacing.large,
+    backgroundColor: Theme.colors.surface
+  },
+  modeCardContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 8,
+    padding: Theme.spacing.large,
+    marginTop: Theme.spacing.large,
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.1,
+    shadowRadius: 2,
+    elevation: 2
+  },
+  modeCardLeft: {
+    marginRight: Theme.spacing.large
+  },
+  modeCardAvatar: {
+    backgroundColor: '#EEF2F7'
+  },
+  modeCardContent: {
+    flex: 1
+  },
+  modeCardRight: {
+    marginLeft: Theme.spacing.small
+  },
+  modeCardTitle: {
+    fontWeight: 'bold',
+    fontSize: 16,
+    color: Theme.colors.primary
+  },
+  modeCardDescription: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    marginTop: 4
+  },
+  modeCardChevron: {
+    fontSize: 24,
+    color: '#888888'
+  },
+  modeTitle: {
+    fontWeight: 'bold',
+    color: Theme.colors.primary
+  },
+  modeDescription: {
+    color: Theme.colors.text,
+    marginTop: 4
   }
 });

--- a/src/types/sortation.ts
+++ b/src/types/sortation.ts
@@ -101,4 +101,6 @@ export type SortationPutawayScreenType = {
   taskList: PutawayDetailsModel[];
   currentTaskIndex: number;
   isDirectPutaway?: boolean;
+  isUserDirected?: boolean;
+  containerId?: string;
 };

--- a/src/types/sortation.ts
+++ b/src/types/sortation.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-undef */
 import LocationType from '../data/location/LocationType';
-import InventoryItem from '../data/picklist/InventoryItem';
 import Person from '../data/picklist/Person';
 
 export type SortationProduct = {
@@ -21,6 +20,7 @@ export type SortationProduct = {
   productCode: string;
   unitOfMeasure: string;
   updatedBy: string;
+  upc?: string;
 };
 
 export type SortationFacility = {
@@ -82,25 +82,4 @@ export type DetailChip = {
   icon: string;
   label: string;
   value: string | null | number | undefined;
-};
-
-export type PutawayDetailsModel = {
-  id: string;
-  type: string;
-  status: string;
-  identifier: string;
-  inventoryItem: InventoryItem;
-  facility: SortationFacility;
-  location: SortationLocation;
-  quantity: number;
-  container: SortationLocation;
-  destination: SortationLocation;
-};
-
-export type SortationPutawayScreenType = {
-  taskList: PutawayDetailsModel[];
-  currentTaskIndex: number;
-  isDirectPutaway?: boolean;
-  isUserDirected?: boolean;
-  containerId?: string;
 };

--- a/src/utils/ApiClient.ts
+++ b/src/utils/ApiClient.ts
@@ -34,8 +34,8 @@ class _ApiClient {
     return await this.client.delete(endpoint, config);
   }
 
-  async patch(endpoint: string, config = this.client.defaults) {
-    return await this.client.patch(endpoint, config);
+  async patch(endpoint: string, data: any, config = this.client.defaults) {
+    return await this.client.patch(endpoint, data, config);
   }
 
   handleApiSuccess = (response: AxiosResponse) => {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { appConfig, DEFAULT_DATE_FORMAT_OPTIONS } from '../constants';
 import Product from '../data/product/Product';
+import { SortationProduct } from '../types/sortation';
 
 export function parseResponse(data) {
   if (_.isArray(data)) {
@@ -68,7 +69,10 @@ export function parseFromISODateToLocaleString(dateStr: Date | string): string {
  * @param product The product to validate against.
  * @returns True if the scanned barcode is valid, false otherwise.
  */
-export function isProductBarcodeValid(scannedBarcode: string, product: Product | null | undefined): boolean {
+export function isProductBarcodeValid(
+  scannedBarcode: string,
+  product: Product | SortationProduct | null | undefined
+): boolean {
   if (!scannedBarcode || !product) {
     return false;
   }


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-630

**New Screens**                                                                           
  - _PutawayModeScreen_ (Screen 1a) - Choose between System-Directed and User-Directed putaway modes. Displays container ID and task summary (items across zones).
  - _PutawayTaskListScreen_ (Screen 1b/1c) - Zone-grouped task list with SKU scan/search
  filtering. Single match auto-navigates; clearing filter restores full list.

  **Workflow Changes**
  - Container scan now navigates to Mode Selection instead of directly to Location Scan
  - System-Directed mode sequences tasks from index 0; User-Directed lets the user pick any
   task
  - After completing a task: User-Directed returns to Task List; System-Directed advances
  to next task
  - User-Directed screens show "Back To List" button instead of Skip
  - Task counter (1 / 5) shown only in System-Directed mode

**Video**
https://github.com/user-attachments/assets/266bf2d6-5b5c-404b-9bf4-701490e6cb08
