### PR TITLE
OBLS-630 Fix issues around user directed putaway

### DIFF
--- a/src/screens/SortationPutaway/PutawayEntryScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayEntryScreen.tsx
@@ -1,26 +1,27 @@
 import React, { useCallback, useState } from 'react';
 import { Alert, ScrollView } from 'react-native';
 import { Paragraph, Title } from 'react-native-paper';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING } from '../../constants';
 import { navigate } from '../../NavigationService';
 import { getPutawayDetailsByContainerId } from '../../redux/actions/putaways';
-import { RootState } from '../../redux/reducers';
+import { SortationTask } from '../../types/sortation';
 import styles from './styles';
 
 export default function PutawayEntryScreen() {
   const [putawayContainerId, setPutawayContainerId] = useState<string>(EMPTY_STRING);
   const dispatch = useDispatch();
-  const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks);
 
   const performScan = useCallback(
     (containerId: string) => {
       dispatch(
         getPutawayDetailsByContainerId(containerId, (response) => {
           if (response && !response.error) {
-            if (putawayTasks.length > 0) {
+            const allTasks: SortationTask[] = response?.response?.data || [];
+
+            if (allTasks.length > 0) {
               navigate('SortationPutawayMode', {
                 containerId
               });
@@ -35,7 +36,7 @@ export default function PutawayEntryScreen() {
         })
       );
     },
-    [dispatch, putawayTasks]
+    [dispatch]
   );
 
   return (

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -46,7 +46,7 @@ export default function PutawayLocationScanScreen() {
 
   useEffect(() => {
     setPutawayLocationBarcode(EMPTY_STRING);
-  }, [currentTaskIndex]);
+  }, [currentTaskIndex, putawayDetails?.id]);
 
   if (!putawayDetails) {
     return (

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -166,8 +166,11 @@ export default function PutawayQuantityScreen() {
               handleResponseAfterComplete
             )
           );
+        } else if (isUserDirected && containerId) {
+          // User-Directed: go back to task list after partial putaway
+          navigate('SortationPutawayTaskList', { containerId });
         } else {
-          // Cancel Remaining False - Navigate to Quantity Screen with new task
+          // System-Directed: navigate to Quantity Screen with remaining task
           dispatch(getPutawayDetailsByContainerId(containerId!, () => {}));
           replace('SortationPutawayQuantity', {
             currentTaskIndex: 0,

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -38,8 +38,12 @@ function TaskRow({ task, onPress }: TaskRowProps) {
   return (
     <TouchableOpacity style={styles.taskRow} activeOpacity={0.7} onPress={onPress}>
       <View style={styles.taskRowContent}>
-        <Text style={styles.taskRowProduct}>{productCode}</Text>
-        <Text style={styles.taskRowLocation}>{location}</Text>
+        <Text style={styles.taskRowProduct} numberOfLines={1}>
+          {productCode}
+        </Text>
+        <Text style={styles.taskRowLocation} numberOfLines={1}>
+          {location}
+        </Text>
         <Text style={styles.taskRowQuantity}>{quantity}</Text>
       </View>
     </TouchableOpacity>

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -211,7 +211,7 @@ export default StyleSheet.create({
     fontSize: 16,
     fontWeight: 'bold',
     color: Theme.colors.primary,
-    flex: 2
+    flex: 1
   },
   taskRowLocation: {
     fontSize: 14,
@@ -223,7 +223,7 @@ export default StyleSheet.create({
     fontSize: 14,
     fontWeight: 'bold',
     color: Theme.colors.text,
-    flex: 0.5,
+    flex: 1,
     textAlign: 'right'
   },
   zoneSection: {


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-630?focusedCommentId=74931

Changes:
- Fix the double-scan issue on the initial query - use data from the request, not from the redux store (init empty)
- Fix user-directed partial putaway redirect - now it does redirect to the putaway list instead of newly created task
- Clear location input on task completion - old value stayed in the input, now it's cleared
- Add limit to the length of the table cells (product code was able to overlap other info)

