### PR TITLE
OBLS-630 Fix direct/partial putaway flow

### DIFF
--- a/src/screens/Sortation/SortationQuantityScreen.tsx
+++ b/src/screens/Sortation/SortationQuantityScreen.tsx
@@ -35,9 +35,10 @@ export default function SortationQuantityScreen() {
   useEffect(() => {
     if (directPutawayRequired) {
       navigate('SortationPutawayLocationScan', {
-        taskList: [task],
         currentTaskIndex: 0,
-        isDirectPutaway: true
+        isDirectPutaway: true,
+        isUserDirected: true,
+        task
       });
     }
   }, [directPutawayRequired, product, task]);

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -23,6 +23,7 @@ type PutawayLocationScanRouteProp = RouteProp<
       isDirectPutaway?: boolean;
       isUserDirected?: boolean;
       containerId?: string;
+      task?: SortationTask;
     };
   },
   'SortationPutawayLocationScan'
@@ -30,9 +31,9 @@ type PutawayLocationScanRouteProp = RouteProp<
 
 export default function PutawayLocationScanScreen() {
   const { params } = useRoute<PutawayLocationScanRouteProp>();
-  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task } = params;
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
-  const putawayDetails = putawayTasks?.[currentTaskIndex];
+  const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
 
   const [putawayLocationBarcode, setPutawayLocationBarcode] = useState<string>(EMPTY_STRING);
   const [isDialogVisible, setIsDialogVisible] = useState(false);
@@ -75,7 +76,8 @@ export default function PutawayLocationScanScreen() {
       currentTaskIndex,
       isDirectPutaway,
       isUserDirected,
-      containerId
+      containerId,
+      task
     });
   }
 
@@ -130,7 +132,7 @@ export default function PutawayLocationScanScreen() {
             Submit
           </Button>
 
-          {isUserDirected ? (
+          {task ? null : isUserDirected ? (
             <Button
               style={styles.topSpace}
               title="Back To List"

--- a/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
@@ -23,6 +23,7 @@ type PutawayProductScanRouteProp = RouteProp<
       isDirectPutaway?: boolean;
       isUserDirected?: boolean;
       containerId?: string;
+      task?: SortationTask;
     };
   },
   'SortationPutawayProductScan'
@@ -30,9 +31,9 @@ type PutawayProductScanRouteProp = RouteProp<
 
 export default function PutawayProductScanScreen() {
   const { params } = useRoute<PutawayProductScanRouteProp>();
-  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task } = params;
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
-  const putawayDetails = putawayTasks?.[currentTaskIndex];
+  const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
   const [putawayProductBarcode, setPutawayProductBarcode] = useState<string>(EMPTY_STRING);
 
   if (!putawayDetails) {
@@ -63,7 +64,8 @@ export default function PutawayProductScanScreen() {
       currentTaskIndex,
       isDirectPutaway,
       isUserDirected,
-      containerId
+      containerId,
+      task
     });
   }
 

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -171,13 +171,16 @@ export default function PutawayQuantityScreen() {
           navigate('SortationPutawayTaskList', { containerId });
         } else {
           // System-Directed: navigate to Quantity Screen with remaining task
-          dispatch(getPutawayDetailsByContainerId(containerId!, () => {}));
-          replace('SortationPutawayQuantity', {
-            currentTaskIndex: 0,
-            isDirectPutaway,
-            isUserDirected,
-            containerId
-          });
+          dispatch(
+            getPutawayDetailsByContainerId(containerId!, () => {
+              replace('SortationPutawayLocationScan', {
+                currentTaskIndex: 0,
+                isDirectPutaway,
+                isUserDirected,
+                containerId
+              });
+            })
+          );
         }
       })
     );

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -25,6 +25,7 @@ type PutawayQuantityRouteProp = RouteProp<
       isDirectPutaway?: boolean;
       isUserDirected?: boolean;
       containerId?: string;
+      task?: SortationTask;
     };
   },
   'SortationPutawayQuantity'
@@ -37,9 +38,9 @@ type ReasonCode = {
 
 export default function PutawayQuantityScreen() {
   const { params } = useRoute<PutawayQuantityRouteProp>();
-  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId } = params;
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task } = params;
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
-  const putawayDetails = putawayTasks?.[currentTaskIndex];
+  const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
   const dispatch = useDispatch();
 
   const inputRef = useRef<TextInput | null>(null);
@@ -166,6 +167,9 @@ export default function PutawayQuantityScreen() {
               handleResponseAfterComplete
             )
           );
+        } else if (task) {
+          // Direct Putaway: partial done, remaining task lives on backend
+          navigate('Sortation');
         } else if (isUserDirected && containerId) {
           // User-Directed: go back to task list after partial putaway
           navigate('SortationPutawayTaskList', { containerId });
@@ -196,7 +200,10 @@ export default function PutawayQuantityScreen() {
     if (response && !response.error) {
       Alert.alert('Putaway Successful', 'The putaway was successful.');
 
-      if (isUserDirected && containerId) {
+      if (task) {
+        // Direct Putaway: single task done, go back to Sortation
+        navigate('Sortation');
+      } else if (isUserDirected && containerId) {
         navigate('SortationPutawayTaskList', { containerId });
       } else {
         // Re-fetch removes the completed task, so remaining tasks shift down.


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-630

Changes:
- Fix broken Direct Putaway flow - Direct Putaway never dispatches getPutawayDetailsByContainerId, so the  Redux store is empty
- Allow putaway screens (LocationScan, ProductScan, Quantity) to accept an optional task route param, used exclusively by the Direct Putaway flow 
- Pass isUserDirected: true from SortationQuantityScreen so existing UI logic (no task   
  counter, no skip button) applies
- On completion (full or partial), navigate back to Sortation - the remaining task reachable from sortation putaway