### PR TITLE
OBLS-635 Fix unreliable keyboard auto-focus on quantity input screens…

### DIFF
--- a/src/components/ScannerInput.tsx
+++ b/src/components/ScannerInput.tsx
@@ -1,6 +1,13 @@
 import { useIsFocused } from '@react-navigation/native';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
-import { AppState, Keyboard, TextInput as NativeTextInput, StyleProp, ViewStyle } from 'react-native';
+import {
+  AppState,
+  InteractionManager,
+  Keyboard,
+  TextInput as NativeTextInput,
+  StyleProp,
+  ViewStyle
+} from 'react-native';
 import { TextInput as PaperTextInput } from 'react-native-paper';
 import { useSelector } from 'react-redux';
 
@@ -9,6 +16,8 @@ import { appConfig } from '../constants';
 import { RootState } from '../redux/reducers';
 import Theme from '../utils/Theme';
 import { KeyboardIcon, ScanIcon } from './Icons';
+
+const POST_TRANSITION_FOCUS_DELAY = 300;
 
 type ScannerInputProps = {
   value: string;
@@ -104,10 +113,15 @@ export const ScannerInput = forwardRef<NativeTextInput, ScannerInputProps>(
       }
     }, [shouldBeFocused]);
 
-    // Focus once on mount
+    // Focus once on mount if the screen is focused, and whenever focus state changes
+    // Wait for navigation/animation transitions to complete, then delay slightly
+    // to ensure the native view has fully laid out before requesting focus
     useEffect(() => {
       if (shouldBeFocused) {
-        requestFocus();
+        const handle = InteractionManager.runAfterInteractions(() => {
+          setTimeout(requestFocus, POST_TRANSITION_FOCUS_DELAY);
+        });
+        return () => handle.cancel();
       }
     }, [requestFocus, shouldBeFocused]);
 

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -1,12 +1,14 @@
 import { useIsFocused } from '@react-navigation/native';
 import * as React from 'react';
-import { Alert, TextInput, View } from 'react-native';
-import { Button, Divider, TextInput as PaperTextInput, Paragraph, Subheading } from 'react-native-paper';
+import { Alert, View } from 'react-native';
+import { Button, Divider, Paragraph, Subheading } from 'react-native-paper';
 import { useDispatch } from 'react-redux';
 
+import { QuantityIcon } from '../../components/Icons';
 import PickingShortAndReasonModal from '../../components/PickingShortAndReasonModal';
 import { ProductDetails } from '../../components/ProductDetails';
-import { HYPHEN, INPUT_FOCUS_DELAY_TIME_IN_MS } from '../../constants';
+import { ScannerInput } from '../../components/ScannerInput';
+import { HYPHEN } from '../../constants';
 import { navigate } from '../../NavigationService';
 import { getReasonCodesAction } from '../../redux/actions/others';
 import { ReasonCode } from '../../types/picking';
@@ -19,7 +21,6 @@ export default function PickingPickQuantityScreen() {
   const { currentTask, currentTaskIndex, allTasksCount, shortPickTask, revalidateCurrentTask, goToNextTask } =
     usePickingContext();
   const dispatch = useDispatch();
-  const inputRef = React.useRef<TextInput | null>(null);
   const isFocused = useIsFocused();
 
   const [quantityPicked, setQuantityPicked] = React.useState<string>('');
@@ -27,14 +28,12 @@ export default function PickingPickQuantityScreen() {
   const [selectedReasonCode, setSelectedReasonCode] = React.useState<ReasonCode | undefined>(undefined);
   const [isShortModalVisible, setIsShortModalVisible] = React.useState(false);
 
-  // Focus input when screen is focused
+  // Reset quantity when screen is focused
   React.useEffect(() => {
     if (!isFocused) {
       return;
     }
     setQuantityPicked('');
-    const t = setTimeout(() => inputRef.current?.focus(), INPUT_FOCUS_DELAY_TIME_IN_MS);
-    return () => clearTimeout(t);
   }, [isFocused]);
 
   // Fetch reason codes
@@ -162,16 +161,16 @@ export default function PickingPickQuantityScreen() {
             Please enter the quantity of the product that you have picked from the location.
           </Paragraph>
 
-          <PaperTextInput
-            style={styles.marginTop}
-            autoCompleteType="off"
-            ref={inputRef}
-            mode="outlined"
+          <ScannerInput
+            showKeyboardOnMount
+            autoSubmitTimeout={0}
+            keyboardType="number-pad"
+            leftIcon={<QuantityIcon size={24} />}
             label="Quantity Picked"
             value={quantityPicked}
-            keyboardType="numeric"
-            returnKeyType="done"
-            onChangeText={setQuantityPicked}
+            isEnabled={!isShortModalVisible}
+            onChange={setQuantityPicked}
+            onSubmit={handleSubmit}
           />
 
           <Button mode="contained" style={styles.marginTop} onPress={handleSubmit}>

--- a/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
+++ b/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
@@ -101,6 +101,12 @@ export default function AlternativeLocationSelector({
     onDismiss();
   };
 
+  // Don't render anything if not visible
+  // This ensures we do not fight for focus with the scanner input when the modal is closed
+  if (!visible) {
+    return null;
+  }
+
   return (
     <Modal transparent visible={visible} animationType="slide" onRequestClose={onDismiss}>
       <View style={styles.modalOverlay}>
@@ -125,8 +131,6 @@ export default function AlternativeLocationSelector({
           <ScannerInput
             label="Scan location number"
             value={scannedLocationInput}
-            // Only fight for focus if the modal is actually visible
-            isEnabled={visible}
             onChange={setScannedLocationInput}
             onSubmit={handleLocationSearch}
           />

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -1,13 +1,14 @@
 import { RouteProp, useIsFocused, useRoute } from '@react-navigation/native';
-import React, { useEffect, useRef, useState } from 'react';
-import { Alert, ScrollView, TextInput, View } from 'react-native';
-import { Divider, TextInput as PaperTextInput, Paragraph, Portal, Subheading, Switch } from 'react-native-paper';
+import React, { useEffect, useState } from 'react';
+import { Alert, ScrollView, View } from 'react-native';
+import { Divider, Paragraph, Portal, Subheading, Switch } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
 import AsyncModalSelect from '../../components/AsyncModalSelect';
 import Button from '../../components/Button';
 import EmptyView from '../../components/EmptyView';
-import { INPUT_FOCUS_DELAY_TIME_IN_MS } from '../../constants';
+import { QuantityIcon } from '../../components/Icons';
+import { ScannerInput } from '../../components/ScannerInput';
 import { navigate, replace } from '../../NavigationService';
 import { getReasonCodesAction } from '../../redux/actions/others';
 import { getPutawayDetailsByContainerId, patchPutawayTaskAction } from '../../redux/actions/putaways';
@@ -43,7 +44,6 @@ export default function PutawayQuantityScreen() {
   const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
   const dispatch = useDispatch();
 
-  const inputRef = useRef<TextInput | null>(null);
   const isFocused = useIsFocused();
 
   const [putawayQuantity, setPutawayQuantity] = useState<number | undefined>();
@@ -76,8 +76,7 @@ export default function PutawayQuantityScreen() {
     if (!isFocused) {
       return;
     }
-    const t = setTimeout(() => inputRef.current?.focus(), INPUT_FOCUS_DELAY_TIME_IN_MS);
-    return () => clearTimeout(t);
+    setPutawayQuantity(undefined);
   }, [isFocused]);
 
   if (!putawayDetails) {
@@ -246,16 +245,16 @@ export default function PutawayQuantityScreen() {
 
         <View style={styles.formContainer}>
           <Subheading style={styles.subheading}>Enter Putaway Quantity</Subheading>
-          <PaperTextInput
-            ref={inputRef}
-            autoCompleteType="off"
-            style={styles.topSpace}
-            mode="outlined"
-            label="Putaway Quantity Entry Field"
+          <ScannerInput
+            showKeyboardOnMount
+            autoSubmitTimeout={0}
             keyboardType="number-pad"
-            value={putawayQuantity?.toString() || ''}
-            returnKeyType="done"
-            onChangeText={handleChange}
+            leftIcon={<QuantityIcon size={24} />}
+            label="Putaway Quantity"
+            value={putawayQuantity?.toString() ?? ''}
+            isEnabled={!isDialogVisible}
+            onChange={handleChange}
+            onSubmit={handleConfirm}
           />
 
           <View style={styles.topSpace}>


### PR DESCRIPTION
… (putaway, picking)

https://openboxes.atlassian.net/browse/OBLS-635

Summary
- Replace PaperTextInput with ScannerInput on quantity screens in Picking and SortationPutaway flows, matching the pattern already used in Sortation
- Fix ScannerInput mount focus timing by combining InteractionManager.runAfterInteractions with a post-transition delay to ensure keyboard reliably appears
- Prevent focus fighting in PutawayQuantityScreen by unmounting AlternativeLocationSelector when not visible