### PR TITLE
OBLS-370 Fix back navigation after completing all pick tasks

### DIFF
--- a/src/NavigationService.ts
+++ b/src/NavigationService.ts
@@ -24,6 +24,15 @@ export function reset(routeName: string) {
   );
 }
 
+export function resetToRoutes(routes: { name: string; params?: any }[]) {
+  navigationRef.current?.dispatch(
+    CommonActions.reset({
+      index: routes.length - 1,
+      routes
+    })
+  );
+}
+
 export function goBack() {
   navigationRef.current?.dispatch(CommonActions.goBack());
 }

--- a/src/screens/Picking/lib.ts
+++ b/src/screens/Picking/lib.ts
@@ -1,5 +1,5 @@
 import { Alert } from 'react-native';
-import { navigate } from '../../NavigationService';
+import { navigate, resetToRoutes } from '../../NavigationService';
 import { PickTask } from '../../types/picking';
 
 export function revalidateTaskAndProceed(
@@ -39,7 +39,7 @@ export function revalidateTaskAndProceed(
     Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
       {
         text: 'OK',
-        onPress: () => navigate('PickingPickStagingLocation')
+        onPress: () => resetToRoutes([{ name: 'PickingPickType' }, { name: 'PickingPickStagingLocation' }])
       }
     ]);
   });


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-370

Changes:
- Add resetToRoutes helper to NavigationService for resetting the navigation stack to multiple routes
- After all pick tasks complete, reset the stack to [PickingPickType, PickingPickStagingLocation] so the back button returns to the pick type screen instead of walking back through completed task screens