### PR TITLE
OBLS-688 Add server profiles feature with multi-env support

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-native/no-inline-styles */
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import React, { Component } from 'react';
@@ -13,6 +12,7 @@ import { appConfig } from './constants';
 import { Session } from './data/auth/Session';
 import Location from './data/location/Location';
 import * as NavigationService from './NavigationService';
+import { migrate } from './components/ProfileStorage';
 import { getSessionAction } from './redux/actions/main';
 import { RootState } from './redux/reducers';
 import AdjustStock from './screens/AdjustStock';
@@ -47,6 +47,7 @@ import PutawayDetails from './screens/PutawayDetails';
 import PutawayItem from './screens/PutawayItem';
 import PutawayItemDetail from './screens/PutawayItemDetail';
 import PutawayList from './screens/PutawayList';
+import ProfilesScreen from './screens/Profiles';
 import Scan from './screens/Scan';
 import Settings from './screens/Settings';
 import ShipItemDetails from './screens/ShipItemDetails';
@@ -121,16 +122,6 @@ class Main extends Component<Props, State> {
     };
   }
 
-  UNSAFE_componentWillMount() {
-    AsyncStorage.getItem('API_URL').then((value) => {
-      if (!value) {
-        NavigationService.navigate('Settings');
-      } else {
-        ApiClient.setBaseUrl(value);
-      }
-    });
-  }
-
   shouldComponentUpdate(nextProps: Props) {
     return (
       this.props.fullScreenLoadingIndicator.visible !== nextProps.fullScreenLoadingIndicator.visible ||
@@ -161,8 +152,21 @@ class Main extends Component<Props, State> {
 
   componentDidMount() {
     SplashScreen.hide();
-    AsyncStorage.setItem('launched', 'true');
   }
+
+  onNavigatorReady = () => {
+    migrate()
+      .then((serverUrl) => {
+        if (serverUrl) {
+          ApiClient.setBaseUrl(serverUrl);
+        } else {
+          NavigationService.navigate('Profiles');
+        }
+      })
+      .catch(() => {
+        NavigationService.navigate('Profiles');
+      });
+  };
 
   render() {
     const { loggedIn } = this.props;
@@ -174,7 +178,7 @@ class Main extends Component<Props, State> {
             visible={this.props.fullScreenLoadingIndicator.visible}
             message={this.props.fullScreenLoadingIndicator.message}
           />
-          <NavigationContainer ref={NavigationService.navigationRef}>
+          <NavigationContainer ref={NavigationService.navigationRef} onReady={this.onNavigatorReady}>
             <Stack.Navigator
               initialRouteName={initialRouteName}
               screenOptions={({ route, navigation }) => ({
@@ -246,6 +250,7 @@ class Main extends Component<Props, State> {
                 options={{ title: 'Receive Detail' }}
               />
               <Stack.Screen name="Settings" component={Settings} options={{ title: 'Settings' }} />
+              <Stack.Screen name="Profiles" component={ProfilesScreen} options={{ title: 'Server Profiles' }} />
               <Stack.Screen name="OutboundStockList" component={OutboundStockList} options={{ title: 'Packing' }} />
               <Stack.Screen
                 name="OutboundStockDetails"

--- a/src/components/ProfileCardSkeleton.tsx
+++ b/src/components/ProfileCardSkeleton.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+
+export default function ProfileCardSkeleton() {
+  return (
+    <View style={styles.card}>
+      <View style={styles.row}>
+        <View style={styles.inner}>
+          <View style={[styles.block, styles.title]} />
+          <View style={styles.row}>
+            <View style={[styles.block, styles.icon]} />
+            <View style={styles.inner}>
+              <View style={[styles.block, styles.label]} />
+              <View style={[styles.block, styles.url]} />
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#f5f6f8',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    marginBottom: 20
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  inner: {
+    flex: 1
+  },
+  block: {
+    backgroundColor: '#e0e0e0',
+    borderRadius: 4
+  },
+  title: {
+    width: 90,
+    height: 10,
+    marginBottom: 8
+  },
+  icon: {
+    width: 22,
+    height: 22,
+    marginRight: 12
+  },
+  label: {
+    width: 120,
+    height: 14,
+    marginBottom: 6
+  },
+  url: {
+    width: 180,
+    height: 10
+  }
+});

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { Profile, ProfileStorageData } from '../types/profile';
+import { createEventEmitter } from '../utils/EventEmitter';
 
 function generateId(): string {
   return Date.now().toString(36) + Math.random().toString(36).slice(2);
@@ -10,7 +11,10 @@ const PROFILES_KEY = 'PROFILES';
 const LEGACY_API_URL_KEY = 'API_URL';
 const CURRENT_VERSION = 1;
 
-function createDefaultStorage(): ProfileStorageData {
+const emitter = createEventEmitter();
+export const subscribe = emitter.subscribe;
+
+export function createDefaultStorage(): ProfileStorageData {
   return {
     version: CURRENT_VERSION,
     activeProfileId: null,
@@ -50,6 +54,7 @@ async function readStorage(): Promise<ProfileStorageData> {
 
 async function writeStorage(data: ProfileStorageData): Promise<void> {
   await AsyncStorage.setItem(PROFILES_KEY, JSON.stringify(data));
+  emitter.emit();
 }
 
 export function createProfile(label: string, serverUrl: string): Profile {
@@ -112,7 +117,15 @@ export async function migrate(): Promise<string | null> {
     return profile.serverUrl;
   }
 
-  return null;
+  const defaultProfile = createProfile('Staging', 'https://vvg.openboxes.com/openboxes/api');
+  const defaultData: ProfileStorageData = {
+    version: CURRENT_VERSION,
+    activeProfileId: defaultProfile.id,
+    profiles: [defaultProfile]
+  };
+  await writeStorage(defaultData);
+
+  return defaultProfile.serverUrl;
 }
 
 export async function getProfiles(): Promise<ProfileStorageData> {

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -12,7 +12,7 @@ const LEGACY_API_URL_KEY = 'API_URL';
 const CURRENT_VERSION = 1;
 
 const DEFAULT_SERVERS = [
-  { label: 'Staging Server', serverUrl: 'http://stag.vtc.openboxes.com/openboxes/api' },
+  { label: 'Staging Server', serverUrl: 'https://stag.vtc.openboxes.com/openboxes/api' },
   { label: 'Test Server', serverUrl: 'https://vvg.openboxes.com/openboxes/api' }
 ];
 

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -88,8 +88,14 @@ export async function migrate(): Promise<string | null> {
   const data = await readStorage();
 
   if (data.profiles.length > 0) {
-    const active = data.profiles.find((p) => p.id === data.activeProfileId);
-    return active?.serverUrl ?? data.profiles[0]?.serverUrl ?? null;
+    let active = data.profiles.find((p) => p.id === data.activeProfileId);
+
+    if (!active && data.profiles[0]) {
+      active = data.profiles[0];
+      await writeStorage({ ...data, activeProfileId: active.id });
+    }
+
+    return active?.serverUrl ?? null;
   }
 
   const legacyUrl = await AsyncStorage.getItem(LEGACY_API_URL_KEY);

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -12,7 +12,7 @@ const LEGACY_API_URL_KEY = 'API_URL';
 const CURRENT_VERSION = 1;
 
 const DEFAULT_SERVERS = [
-  { label: 'Staging Server', serverUrl: 'http://stag.vtc.openboxes.com/' },
+  { label: 'Staging Server', serverUrl: 'http://stag.vtc.openboxes.com/openboxes/api' },
   { label: 'Test Server', serverUrl: 'https://vvg.openboxes.com/openboxes/api' }
 ];
 

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -1,0 +1,165 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { Profile, ProfileStorageData } from '../types/profile';
+
+function generateId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2);
+}
+
+const PROFILES_KEY = 'PROFILES';
+const LEGACY_API_URL_KEY = 'API_URL';
+const CURRENT_VERSION = 1;
+
+function createDefaultStorage(): ProfileStorageData {
+  return {
+    version: CURRENT_VERSION,
+    activeProfileId: null,
+    profiles: []
+  };
+}
+
+function parseStorageData(raw: string | null): ProfileStorageData {
+  if (!raw) {
+    return createDefaultStorage();
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    return {
+      version: parsed.version ?? CURRENT_VERSION,
+      activeProfileId: parsed.activeProfileId ?? null,
+      profiles: Array.isArray(parsed.profiles)
+        ? parsed.profiles.map((p: any) => ({
+            id: p.id ?? generateId(),
+            label: p.label ?? 'Unknown',
+            serverUrl: p.serverUrl ?? '',
+            settings: p.settings ?? {}
+          }))
+        : []
+    };
+  } catch {
+    return createDefaultStorage();
+  }
+}
+
+async function readStorage(): Promise<ProfileStorageData> {
+  const raw = await AsyncStorage.getItem(PROFILES_KEY);
+  return parseStorageData(raw);
+}
+
+async function writeStorage(data: ProfileStorageData): Promise<void> {
+  await AsyncStorage.setItem(PROFILES_KEY, JSON.stringify(data));
+}
+
+export function createProfile(label: string, serverUrl: string): Profile {
+  return {
+    id: generateId(),
+    label,
+    serverUrl: serverUrl.trim(),
+    settings: {}
+  };
+}
+
+export function validateUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return 'URL is required';
+  }
+  if (!/^https?:\/\/.+/i.test(trimmed)) {
+    return 'URL must start with http:// or https://';
+  }
+  return null;
+}
+
+export function validateProfile(label: string, serverUrl: string): string | null {
+  if (!label.trim()) {
+    return 'Profile label is required';
+  }
+  return validateUrl(serverUrl);
+}
+
+/**
+ * Migrates from the legacy single API_URL key to the profiles system.
+ * If profiles already exist, this is a no-op.
+ * Returns the active profile's server URL (or null if no profiles exist).
+ */
+export async function migrate(): Promise<string | null> {
+  const data = await readStorage();
+
+  if (data.profiles.length > 0) {
+    const active = data.profiles.find((p) => p.id === data.activeProfileId);
+    return active?.serverUrl ?? data.profiles[0]?.serverUrl ?? null;
+  }
+
+  const legacyUrl = await AsyncStorage.getItem(LEGACY_API_URL_KEY);
+
+  if (legacyUrl) {
+    const profile = createProfile('Default', legacyUrl);
+    const newData: ProfileStorageData = {
+      version: CURRENT_VERSION,
+      activeProfileId: profile.id,
+      profiles: [profile]
+    };
+    await writeStorage(newData);
+    await AsyncStorage.removeItem(LEGACY_API_URL_KEY);
+    return profile.serverUrl;
+  }
+
+  return null;
+}
+
+export async function getProfiles(): Promise<ProfileStorageData> {
+  return readStorage();
+}
+
+export async function getActiveProfile(): Promise<Profile | null> {
+  const data = await readStorage();
+  if (!data.activeProfileId) {
+    return data.profiles[0] ?? null;
+  }
+  return data.profiles.find((p) => p.id === data.activeProfileId) ?? data.profiles[0] ?? null;
+}
+
+export async function setActiveProfileId(id: string): Promise<void> {
+  const data = await readStorage();
+  const exists = data.profiles.some((p) => p.id === id);
+  if (exists) {
+    data.activeProfileId = id;
+    await writeStorage(data);
+  }
+}
+
+export async function saveProfile(profile: Profile): Promise<void> {
+  const data = await readStorage();
+  const index = data.profiles.findIndex((p) => p.id === profile.id);
+
+  if (index >= 0) {
+    data.profiles[index] = profile;
+  } else {
+    data.profiles.push(profile);
+  }
+
+  if (!data.activeProfileId && data.profiles.length === 1) {
+    data.activeProfileId = profile.id;
+  }
+
+  await writeStorage(data);
+}
+
+export async function deleteProfile(id: string): Promise<boolean> {
+  const data = await readStorage();
+
+  if (data.profiles.length <= 1) {
+    return false;
+  }
+
+  data.profiles = data.profiles.filter((p) => p.id !== id);
+
+  if (data.activeProfileId === id) {
+    data.activeProfileId = data.profiles[0]?.id ?? null;
+  }
+
+  await writeStorage(data);
+  return true;
+}

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { Profile, ProfileStorageData } from '../types/profile';
+import { environment } from '../utils/Environment';
 import { createEventEmitter } from '../utils/EventEmitter';
 
 function generateId(): string {
@@ -117,7 +118,7 @@ export async function migrate(): Promise<string | null> {
     return profile.serverUrl;
   }
 
-  const defaultProfile = createProfile('Staging', 'https://vvg.openboxes.com/openboxes/api');
+  const defaultProfile = createProfile('Staging', environment.API_BASE_URL);
   const defaultData: ProfileStorageData = {
     version: CURRENT_VERSION,
     activeProfileId: defaultProfile.id,

--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -1,7 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { Profile, ProfileStorageData } from '../types/profile';
-import { environment } from '../utils/Environment';
 import { createEventEmitter } from '../utils/EventEmitter';
 
 function generateId(): string {
@@ -12,20 +11,25 @@ const PROFILES_KEY = 'PROFILES';
 const LEGACY_API_URL_KEY = 'API_URL';
 const CURRENT_VERSION = 1;
 
+const DEFAULT_SERVERS = [
+  { label: 'Staging Server', serverUrl: 'http://stag.vtc.openboxes.com/' },
+  { label: 'Test Server', serverUrl: 'https://vvg.openboxes.com/openboxes/api' }
+];
+
 const emitter = createEventEmitter();
 export const subscribe = emitter.subscribe;
 
-export function createDefaultStorage(): ProfileStorageData {
+export function createStorage(profiles: Profile[] = [], activeProfileId?: string): ProfileStorageData {
   return {
     version: CURRENT_VERSION,
-    activeProfileId: null,
-    profiles: []
+    activeProfileId: activeProfileId ?? profiles[0]?.id ?? null,
+    profiles
   };
 }
 
 function parseStorageData(raw: string | null): ProfileStorageData {
   if (!raw) {
-    return createDefaultStorage();
+    return createStorage();
   }
 
   try {
@@ -44,7 +48,7 @@ function parseStorageData(raw: string | null): ProfileStorageData {
         : []
     };
   } catch {
-    return createDefaultStorage();
+    return createStorage();
   }
 }
 
@@ -67,6 +71,10 @@ export function createProfile(label: string, serverUrl: string): Profile {
   };
 }
 
+function normalizeUrl(url: string): string {
+  return url.trim().toLowerCase().replace(/\/+$/, '');
+}
+
 export function validateUrl(url: string): string | null {
   const trimmed = url.trim();
   if (!trimmed) {
@@ -86,47 +94,50 @@ export function validateProfile(label: string, serverUrl: string): string | null
 }
 
 /**
- * Migrates from the legacy single API_URL key to the profiles system.
- * If profiles already exist, this is a no-op.
- * Returns the active profile's server URL (or null if no profiles exist).
+ * Initializes profiles and returns the active server URL.
+ * 1. Profiles exist → use them as-is
+ * 2. No profiles, legacy API_URL exists → create Default (from legacy) + default servers
+ * 3. No profiles, no legacy → create default servers
  */
 export async function migrate(): Promise<string | null> {
   const data = await readStorage();
 
+  // Path 1: profiles already exist
   if (data.profiles.length > 0) {
     let active = data.profiles.find((p) => p.id === data.activeProfileId);
 
-    if (!active && data.profiles[0]) {
+    if (!active) {
       active = data.profiles[0];
-      await writeStorage({ ...data, activeProfileId: active.id });
+      await writeStorage(createStorage(data.profiles, active.id));
     }
 
-    return active?.serverUrl ?? null;
+    return active.serverUrl;
   }
 
+  // Path 2: legacy API_URL migration
   const legacyUrl = await AsyncStorage.getItem(LEGACY_API_URL_KEY);
 
   if (legacyUrl) {
-    const profile = createProfile('Default', legacyUrl);
-    const newData: ProfileStorageData = {
-      version: CURRENT_VERSION,
-      activeProfileId: profile.id,
-      profiles: [profile]
-    };
-    await writeStorage(newData);
+    const legacyProfile = createProfile('Default', legacyUrl);
+    const normalizedLegacy = normalizeUrl(legacyUrl);
+    const profiles = [legacyProfile];
+
+    for (const server of DEFAULT_SERVERS) {
+      if (normalizeUrl(server.serverUrl) !== normalizedLegacy) {
+        profiles.push(createProfile(server.label, server.serverUrl));
+      }
+    }
+
+    await writeStorage(createStorage(profiles, legacyProfile.id));
     await AsyncStorage.removeItem(LEGACY_API_URL_KEY);
-    return profile.serverUrl;
+    return legacyProfile.serverUrl;
   }
 
-  const defaultProfile = createProfile('Staging', environment.API_BASE_URL);
-  const defaultData: ProfileStorageData = {
-    version: CURRENT_VERSION,
-    activeProfileId: defaultProfile.id,
-    profiles: [defaultProfile]
-  };
-  await writeStorage(defaultData);
+  // Path 3: fresh install
+  const profiles = DEFAULT_SERVERS.map((s) => createProfile(s.label, s.serverUrl));
+  await writeStorage(createStorage(profiles));
 
-  return defaultProfile.serverUrl;
+  return profiles[0].serverUrl;
 }
 
 export async function getProfiles(): Promise<ProfileStorageData> {
@@ -160,7 +171,7 @@ export async function saveProfile(profile: Profile): Promise<void> {
     data.profiles.push(profile);
   }
 
-  if (!data.activeProfileId && data.profiles.length === 1) {
+  if (!data.activeProfileId) {
     data.activeProfileId = profile.id;
   }
 

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -16,19 +16,26 @@ type UseProfilesResult = {
   setActive: (id: string) => Promise<void>;
 };
 
+const DEFAULT_DATA: ProfileStorageData = {
+  version: 1,
+  activeProfileId: null,
+  profiles: []
+};
+
 export function useProfiles(): UseProfilesResult {
-  const [data, setData] = useState<ProfileStorageData>({
-    version: 1,
-    activeProfileId: null,
-    profiles: []
-  });
+  const [data, setData] = useState<ProfileStorageData>(DEFAULT_DATA);
   const [loading, setLoading] = useState(true);
   const isFocused = useIsFocused();
 
   const refresh = useCallback(async () => {
-    const stored = await ProfileStorage.getProfiles();
-    setData(stored);
-    setLoading(false);
+    try {
+      const stored = await ProfileStorage.getProfiles();
+      setData(stored);
+    } catch {
+      setData(DEFAULT_DATA);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useIsFocused } from '@react-navigation/native';
+
+import { Profile, ProfileStorageData } from '../types/profile';
+import * as ProfileStorage from '../components/ProfileStorage';
+
+type UseProfilesResult = {
+  profiles: Profile[];
+  activeProfileId: string | null;
+  activeProfile: Profile | null;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  addProfile: (label: string, serverUrl: string) => Promise<Profile>;
+  updateProfile: (profile: Profile) => Promise<void>;
+  removeProfile: (id: string) => Promise<boolean>;
+  setActive: (id: string) => Promise<void>;
+};
+
+export function useProfiles(): UseProfilesResult {
+  const [data, setData] = useState<ProfileStorageData>({
+    version: 1,
+    activeProfileId: null,
+    profiles: []
+  });
+  const [loading, setLoading] = useState(true);
+  const isFocused = useIsFocused();
+
+  const refresh = useCallback(async () => {
+    const stored = await ProfileStorage.getProfiles();
+    setData(stored);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (isFocused) {
+      refresh();
+    }
+  }, [isFocused, refresh]);
+
+  const activeProfile = data.profiles.find((p) => p.id === data.activeProfileId) ?? data.profiles[0] ?? null;
+
+  const addProfile = useCallback(
+    async (label: string, serverUrl: string): Promise<Profile> => {
+      const profile = ProfileStorage.createProfile(label, serverUrl);
+      await ProfileStorage.saveProfile(profile);
+      await refresh();
+      return profile;
+    },
+    [refresh]
+  );
+
+  const updateProfile = useCallback(
+    async (profile: Profile) => {
+      await ProfileStorage.saveProfile(profile);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const removeProfile = useCallback(
+    async (id: string): Promise<boolean> => {
+      const success = await ProfileStorage.deleteProfile(id);
+      if (success) {
+        await refresh();
+      }
+      return success;
+    },
+    [refresh]
+  );
+
+  const setActive = useCallback(
+    async (id: string) => {
+      await ProfileStorage.setActiveProfileId(id);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  return {
+    profiles: data.profiles,
+    activeProfileId: data.activeProfileId,
+    activeProfile,
+    loading,
+    refresh,
+    addProfile,
+    updateProfile,
+    removeProfile,
+    setActive
+  };
+}

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -16,14 +16,8 @@ type UseProfilesResult = {
   setActive: (id: string) => Promise<void>;
 };
 
-const DEFAULT_DATA: ProfileStorageData = {
-  version: 1,
-  activeProfileId: null,
-  profiles: []
-};
-
 export function useProfiles(): UseProfilesResult {
-  const [data, setData] = useState<ProfileStorageData>(DEFAULT_DATA);
+  const [data, setData] = useState<ProfileStorageData>(ProfileStorage.createDefaultStorage);
   const [loading, setLoading] = useState(true);
   const isFocused = useIsFocused();
 
@@ -32,7 +26,7 @@ export function useProfiles(): UseProfilesResult {
       const stored = await ProfileStorage.getProfiles();
       setData(stored);
     } catch {
-      setData(DEFAULT_DATA);
+      setData(ProfileStorage.createDefaultStorage());
     } finally {
       setLoading(false);
     }
@@ -44,44 +38,29 @@ export function useProfiles(): UseProfilesResult {
     }
   }, [isFocused, refresh]);
 
+  useEffect(() => {
+    return ProfileStorage.subscribe(refresh);
+  }, [refresh]);
+
   const activeProfile = data.profiles.find((p) => p.id === data.activeProfileId) ?? data.profiles[0] ?? null;
 
-  const addProfile = useCallback(
-    async (label: string, serverUrl: string): Promise<Profile> => {
-      const profile = ProfileStorage.createProfile(label, serverUrl);
-      await ProfileStorage.saveProfile(profile);
-      await refresh();
-      return profile;
-    },
-    [refresh]
-  );
+  const addProfile = useCallback(async (label: string, serverUrl: string): Promise<Profile> => {
+    const profile = ProfileStorage.createProfile(label, serverUrl);
+    await ProfileStorage.saveProfile(profile);
+    return profile;
+  }, []);
 
-  const updateProfile = useCallback(
-    async (profile: Profile) => {
-      await ProfileStorage.saveProfile(profile);
-      await refresh();
-    },
-    [refresh]
-  );
+  const updateProfile = useCallback(async (profile: Profile) => {
+    await ProfileStorage.saveProfile(profile);
+  }, []);
 
-  const removeProfile = useCallback(
-    async (id: string): Promise<boolean> => {
-      const success = await ProfileStorage.deleteProfile(id);
-      if (success) {
-        await refresh();
-      }
-      return success;
-    },
-    [refresh]
-  );
+  const removeProfile = useCallback(async (id: string): Promise<boolean> => {
+    return ProfileStorage.deleteProfile(id);
+  }, []);
 
-  const setActive = useCallback(
-    async (id: string) => {
-      await ProfileStorage.setActiveProfileId(id);
-      await refresh();
-    },
-    [refresh]
-  );
+  const setActive = useCallback(async (id: string) => {
+    await ProfileStorage.setActiveProfileId(id);
+  }, []);
 
   return {
     profiles: data.profiles,

--- a/src/hooks/useProfiles.ts
+++ b/src/hooks/useProfiles.ts
@@ -17,7 +17,7 @@ type UseProfilesResult = {
 };
 
 export function useProfiles(): UseProfilesResult {
-  const [data, setData] = useState<ProfileStorageData>(ProfileStorage.createDefaultStorage);
+  const [data, setData] = useState<ProfileStorageData>(() => ProfileStorage.createStorage());
   const [loading, setLoading] = useState(true);
   const isFocused = useIsFocused();
 
@@ -26,7 +26,7 @@ export function useProfiles(): UseProfilesResult {
       const stored = await ProfileStorage.getProfiles();
       setData(stored);
     } catch {
-      setData(ProfileStorage.createDefaultStorage());
+      setData(ProfileStorage.createStorage());
     } finally {
       setLoading(false);
     }

--- a/src/redux/reducers/mainReducer.ts
+++ b/src/redux/reducers/mainReducer.ts
@@ -3,7 +3,7 @@ import Location from '../../data/location/Location';
 import { Session } from '../../data/auth/Session';
 import { SHOW_SCREEN_LOADING, HIDE_SCREEN_LOADING, GET_SESSION_REQUEST_SUCCESS, REFRESH_SCREEN } from '../actions/main';
 import { SET_CURRENT_LOCATION_REQUEST_SUCCESS } from '../actions/locations';
-import { LOGIN_REQUEST_SUCCESS } from '../actions/auth';
+import { LOGIN_REQUEST_SUCCESS, LOGOUT_REQUEST_SUCCESS } from '../actions/auth';
 import { GET_PUTAWAY_CANDIDATES_REQUEST_SUCCESS } from '../actions/putaways';
 import { GET_PRODUCT_BY_ID_REQUEST_SUCCESS, GET_PRODUCTS_REQUEST_SUCCESS } from '../actions/products';
 import { FETCH_STOCK_TRANSFERS_SUCCESS } from '../actions/transfers';
@@ -50,6 +50,11 @@ function reducer(state = initialState, action: any) {
       return {
         ...state,
         loggedIn: true
+      };
+    }
+    case LOGOUT_REQUEST_SUCCESS: {
+      return {
+        ...initialState
       };
     }
     case SHOW_SCREEN_LOADING: {

--- a/src/redux/sagas/auth.ts
+++ b/src/redux/sagas/auth.ts
@@ -74,13 +74,13 @@ function* login(action: any) {
 }
 function* logout(action: any) {
   try {
-    yield put(showScreenLoading('Logging out'));
+    yield put(showScreenLoading('Logging Out...'));
     const data = yield call(api.logout, action.payload.data);
     yield put({
       type: LOGOUT_REQUEST_SUCCESS,
       payload: data
     });
-    yield NavigationService.navigate('Login');
+    yield NavigationService.reset('Login');
     yield put(hideScreenLoading());
   } catch (e) {
     yield put(hideScreenLoading());

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-native/no-inline-styles */
 import React, { useState } from 'react';
-import { Image, ScrollView, View } from 'react-native';
-import { TextInput } from 'react-native-paper';
+import { Image, ScrollView, TouchableOpacity, View } from 'react-native';
+import { Caption, Paragraph, TextInput } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useDispatch } from 'react-redux';
 
 import EyeIcon from '../../assets/images/icon_eye.svg';
@@ -9,12 +10,14 @@ import EyeSlashIcon from '../../assets/images/icon_eye_slash.svg';
 import Button from '../../components/Button';
 import showPopup from '../../components/Popup';
 import * as NavigationService from '../../NavigationService';
+import { useProfiles } from '../../hooks/useProfiles';
 import { login } from '../../redux/actions/auth';
 import Theme from '../../utils/Theme';
 import styles from './styles';
 
 const Login = () => {
   const dispatch = useDispatch();
+  const { activeProfile } = useProfiles();
   const [state, setState] = useState<any>({
     username: '',
     password: '',
@@ -77,6 +80,29 @@ const Login = () => {
       <View style={styles.welcomeContainer}>
         <Image source={require('../../assets/images/logo.png')} style={styles.logo} resizeMode="contain" />
       </View>
+      {activeProfile && (
+        <TouchableOpacity
+          style={styles.profileCard}
+          activeOpacity={0.7}
+          onPress={() => NavigationService.navigate('Profiles')}
+        >
+          <View style={styles.profileCardOuter}>
+            <View style={styles.profileCardInner}>
+              <Caption style={styles.profileCardTitle}>CONNECTED TO</Caption>
+              <View style={styles.profileCardContent}>
+                <Icon name="server" size={22} color={Theme.colors.primary} style={styles.profileCardServerIcon} />
+                <View style={styles.profileCardText}>
+                  <Paragraph style={styles.profileCardLabel}>{activeProfile.label}</Paragraph>
+                  <Caption style={styles.profileCardUrl} numberOfLines={1}>
+                    {activeProfile.serverUrl}
+                  </Caption>
+                </View>
+              </View>
+            </View>
+            <Icon name="chevron-right" size={20} color={Theme.colors.disabled} />
+          </View>
+        </TouchableOpacity>
+      )}
       <View style={styles.inputsContainer}>
         <TextInput mode="flat" label={'Username'} placeholder="Username" onChangeText={onUsernameChange} />
         <TextInput

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -4,6 +4,7 @@ import { Image, ScrollView, TouchableOpacity, View } from 'react-native';
 import { Caption, Paragraph, TextInput } from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useDispatch } from 'react-redux';
+import ProfileCardSkeleton from '../../components/ProfileCardSkeleton';
 import EyeIcon from '../../assets/images/icon_eye.svg';
 import EyeSlashIcon from '../../assets/images/icon_eye_slash.svg';
 import Button from '../../components/Button';
@@ -16,7 +17,7 @@ import styles from './styles';
 
 const Login = () => {
   const dispatch = useDispatch();
-  const { activeProfile } = useProfiles();
+  const { activeProfile, loading } = useProfiles();
   const [state, setState] = useState<any>({
     username: '',
     password: '',
@@ -79,7 +80,9 @@ const Login = () => {
       <View style={styles.welcomeContainer}>
         <Image source={require('../../assets/images/logo.png')} style={styles.logo} resizeMode="contain" />
       </View>
-      {activeProfile && (
+      {loading ? (
+        <ProfileCardSkeleton />
+      ) : activeProfile ? (
         <TouchableOpacity
           style={styles.profileCard}
           activeOpacity={0.7}
@@ -101,7 +104,7 @@ const Login = () => {
             <Icon name="chevron-right" size={20} color={Theme.colors.disabled} />
           </View>
         </TouchableOpacity>
-      )}
+      ) : null}
       <View style={styles.inputsContainer}>
         <TextInput mode="flat" label={'Username'} placeholder="Username" onChangeText={onUsernameChange} />
         <TextInput

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -4,7 +4,6 @@ import { Image, ScrollView, TouchableOpacity, View } from 'react-native';
 import { Caption, Paragraph, TextInput } from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useDispatch } from 'react-redux';
-
 import EyeIcon from '../../assets/images/icon_eye.svg';
 import EyeSlashIcon from '../../assets/images/icon_eye_slash.svg';
 import Button from '../../components/Button';

--- a/src/screens/Login/styles.ts
+++ b/src/screens/Login/styles.ts
@@ -24,6 +24,45 @@ const styles = StyleSheet.create({
   logo: {
     width: 120,
     height: 120
+  },
+  profileCard: {
+    backgroundColor: '#f5f6f8',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    marginBottom: 20
+  },
+  profileCardOuter: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  profileCardInner: {
+    flex: 1
+  },
+  profileCardTitle: {
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    marginBottom: 4
+  },
+  profileCardContent: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  profileCardServerIcon: {
+    marginRight: 12
+  },
+  profileCardText: {
+    flex: 1
+  },
+  profileCardLabel: {
+    fontWeight: '600',
+    lineHeight: 18
+  },
+  profileCardUrl: {
+    lineHeight: 14,
+    marginTop: 0
   }
 });
 

--- a/src/screens/Profiles/ProfileFormDialog.tsx
+++ b/src/screens/Profiles/ProfileFormDialog.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, View } from 'react-native';
+import { Paragraph, Text, TextInput } from 'react-native-paper';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import Button from '../../components/Button';
+import { validateProfile } from '../../components/ProfileStorage';
+import { Profile } from '../../types/profile';
+import styles from './styles';
+
+type ProfileFormDialogProps = {
+  visible: boolean;
+  profile: Profile | null;
+  onSave: (label: string, serverUrl: string) => void;
+  onDismiss: () => void;
+};
+
+export default function ProfileFormDialog({ visible, profile, onSave, onDismiss }: ProfileFormDialogProps) {
+  const [formLabel, setFormLabel] = useState('');
+  const [formUrl, setFormUrl] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setFormLabel(profile?.label ?? '');
+      setFormUrl(profile?.serverUrl ?? '');
+      setFormError(null);
+    }
+  }, [visible, profile]);
+
+  const handleSave = useCallback(() => {
+    const error = validateProfile(formLabel, formUrl);
+    if (error) {
+      setFormError(error);
+      return;
+    }
+    onSave(formLabel.trim(), formUrl.trim());
+  }, [formLabel, formUrl, onSave]);
+
+  return (
+    <Modal transparent visible={visible} animationType="fade" onRequestClose={onDismiss}>
+      <View style={styles.modalOverlay}>
+        <View style={styles.modalContent}>
+          <Text style={styles.modalTitle}>{profile ? 'Edit Profile' : 'New Profile'}</Text>
+          <Paragraph style={styles.modalDescription}>
+            {profile ? 'Update the profile name and server URL.' : 'Enter a name and server URL for the new profile.'}
+          </Paragraph>
+
+          <TextInput
+            style={styles.input}
+            mode="outlined"
+            label="Label"
+            placeholder="e.g., Production"
+            value={formLabel}
+            autoCompleteType="off"
+            onChangeText={(t) => {
+              setFormLabel(t);
+              setFormError(null);
+            }}
+          />
+          <TextInput
+            style={styles.input}
+            mode="outlined"
+            label="Server URL"
+            placeholder="https://openboxes.example.com"
+            value={formUrl}
+            autoCompleteType="off"
+            autoCapitalize="none"
+            keyboardType="url"
+            onChangeText={(t) => {
+              setFormUrl(t);
+              setFormError(null);
+            }}
+          />
+          {formError && (
+            <View style={styles.errorBox}>
+              <Icon name="alert-circle-outline" size={16} color="#d32f2f" style={styles.errorIcon} />
+              <Text style={styles.errorText}>{formError}</Text>
+            </View>
+          )}
+
+          <View style={styles.dialogActions}>
+            <Button title="Cancel" mode="outlined" size="100%" style={styles.dialogButtonLeft} onPress={onDismiss} />
+            <Button title="Save" mode="contained" size="100%" style={styles.dialogButtonRight} onPress={handleSave} />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/screens/Profiles/ProfileFormDialog.tsx
+++ b/src/screens/Profiles/ProfileFormDialog.tsx
@@ -11,7 +11,7 @@ import styles from './styles';
 type ProfileFormDialogProps = {
   visible: boolean;
   profile: Profile | null;
-  onSave: (label: string, serverUrl: string) => void;
+  onSave: (label: string, serverUrl: string) => Promise<void>;
   onDismiss: () => void;
 };
 
@@ -28,13 +28,17 @@ export default function ProfileFormDialog({ visible, profile, onSave, onDismiss 
     }
   }, [visible, profile]);
 
-  const handleSave = useCallback(() => {
+  const handleSave = useCallback(async () => {
     const error = validateProfile(formLabel, formUrl);
     if (error) {
       setFormError(error);
       return;
     }
-    onSave(formLabel.trim(), formUrl.trim());
+    try {
+      await onSave(formLabel.trim(), formUrl.trim());
+    } catch (e: any) {
+      setFormError(e?.message || 'Failed to save profile.');
+    }
   }, [formLabel, formUrl, onSave]);
 
   return (

--- a/src/screens/Profiles/index.tsx
+++ b/src/screens/Profiles/index.tsx
@@ -6,7 +6,9 @@ import { useDispatch } from 'react-redux';
 import showPopup from '../../components/Popup';
 import * as ProfileStorage from '../../components/ProfileStorage';
 import { useProfiles } from '../../hooks/useProfiles';
-import { logout } from '../../redux/actions/auth';
+import * as NavigationService from '../../NavigationService';
+import { logout as logoutApi } from '../../apis/auth';
+import { LOGOUT_REQUEST_SUCCESS } from '../../redux/actions/auth';
 import { Profile } from '../../types/profile';
 import ApiClient from '../../utils/ApiClient';
 import Theme from '../../utils/Theme';
@@ -86,17 +88,20 @@ export default function ProfilesScreen() {
             const wasActive = profile.id === activeProfileId;
             const success = await removeProfile(profile.id);
             if (success && wasActive) {
+              await logoutApi(null).catch(() => {});
               const newActive = await ProfileStorage.getActiveProfile();
               if (newActive) {
                 ApiClient.setBaseUrl(newActive.serverUrl);
               }
+              dispatch({ type: LOGOUT_REQUEST_SUCCESS });
+              NavigationService.reset('Login');
             }
           }
         },
         negativeButtonText: 'Cancel'
       });
     },
-    [profiles.length, activeProfileId, removeProfile]
+    [profiles.length, activeProfileId, removeProfile, dispatch]
   );
 
   const handleActivate = useCallback(
@@ -107,9 +112,12 @@ export default function ProfilesScreen() {
         positiveButton: {
           text: 'Switch',
           callback: async () => {
-            dispatch(logout());
+            // Log out directly from the API to ensure the token is revoked, but ignore any errors since we want to switch regardless
+            await logoutApi(null).catch(() => {});
             await setActive(profile.id);
             ApiClient.setBaseUrl(profile.serverUrl);
+            dispatch({ type: LOGOUT_REQUEST_SUCCESS });
+            NavigationService.reset('Login');
           }
         },
         negativeButtonText: 'Cancel'

--- a/src/screens/Profiles/index.tsx
+++ b/src/screens/Profiles/index.tsx
@@ -6,8 +6,7 @@ import { useDispatch } from 'react-redux';
 import showPopup from '../../components/Popup';
 import * as ProfileStorage from '../../components/ProfileStorage';
 import { useProfiles } from '../../hooks/useProfiles';
-import * as NavigationService from '../../NavigationService';
-import { LOGOUT_REQUEST_SUCCESS } from '../../redux/actions/auth';
+import { logout } from '../../redux/actions/auth';
 import { Profile } from '../../types/profile';
 import ApiClient from '../../utils/ApiClient';
 import Theme from '../../utils/Theme';
@@ -59,12 +58,16 @@ export default function ProfilesScreen() {
           ApiClient.setBaseUrl(serverUrl);
         }
       } else {
+        const isFirstProfile = profiles.length === 0;
         await addProfile(label, serverUrl);
+        if (isFirstProfile) {
+          ApiClient.setBaseUrl(serverUrl);
+        }
       }
 
       setDialogVisible(false);
     },
-    [editingProfile, activeProfileId, updateProfile, addProfile]
+    [editingProfile, activeProfileId, updateProfile, addProfile, profiles.length]
   );
 
   const handleDelete = useCallback(
@@ -104,10 +107,9 @@ export default function ProfilesScreen() {
         positiveButton: {
           text: 'Switch',
           callback: async () => {
+            dispatch(logout());
             await setActive(profile.id);
             ApiClient.setBaseUrl(profile.serverUrl);
-            dispatch({ type: LOGOUT_REQUEST_SUCCESS });
-            NavigationService.reset('Login');
           }
         },
         negativeButtonText: 'Cancel'

--- a/src/screens/Profiles/index.tsx
+++ b/src/screens/Profiles/index.tsx
@@ -1,0 +1,213 @@
+import React, { memo, useCallback, useMemo, useState } from 'react';
+import { ScrollView, TouchableOpacity, View } from 'react-native';
+import { Caption, Card, IconButton, Paragraph } from 'react-native-paper';
+
+import { useDispatch } from 'react-redux';
+import showPopup from '../../components/Popup';
+import * as ProfileStorage from '../../components/ProfileStorage';
+import { useProfiles } from '../../hooks/useProfiles';
+import * as NavigationService from '../../NavigationService';
+import { LOGOUT_REQUEST_SUCCESS } from '../../redux/actions/auth';
+import { Profile } from '../../types/profile';
+import ApiClient from '../../utils/ApiClient';
+import Theme from '../../utils/Theme';
+import ProfileFormDialog from './ProfileFormDialog';
+import styles from './styles';
+
+type ProfileRowProps = {
+  profile: Profile;
+  isActive: boolean;
+  isLast: boolean;
+  canDelete: boolean;
+  onActivate: (profile: Profile) => void;
+  onEdit: (profile: Profile) => void;
+  onDelete: (profile: Profile) => void;
+};
+
+export default function ProfilesScreen() {
+  const { profiles, activeProfileId, addProfile, updateProfile, removeProfile, setActive, loading } = useProfiles();
+  const dispatch = useDispatch();
+
+  const [dialogVisible, setDialogVisible] = useState(false);
+  const [editingProfile, setEditingProfile] = useState<Profile | null>(null);
+
+  const sortedProfiles = useMemo(() => {
+    return [...profiles].sort((a, b) => a.label.localeCompare(b.label));
+  }, [profiles]);
+
+  const openCreateDialog = useCallback(() => {
+    setEditingProfile(null);
+    setDialogVisible(true);
+  }, []);
+
+  const openEditDialog = useCallback((profile: Profile) => {
+    setEditingProfile(profile);
+    setDialogVisible(true);
+  }, []);
+
+  const dismissDialog = useCallback(() => {
+    setDialogVisible(false);
+  }, []);
+
+  const handleSave = useCallback(
+    async (label: string, serverUrl: string) => {
+      if (editingProfile) {
+        const updated = { ...editingProfile, label, serverUrl };
+        await updateProfile(updated);
+
+        if (editingProfile.id === activeProfileId) {
+          ApiClient.setBaseUrl(serverUrl);
+        }
+      } else {
+        await addProfile(label, serverUrl);
+      }
+
+      setDialogVisible(false);
+    },
+    [editingProfile, activeProfileId, updateProfile, addProfile]
+  );
+
+  const handleDelete = useCallback(
+    (profile: Profile) => {
+      if (profiles.length <= 1) {
+        showPopup({ message: 'Cannot delete the only profile.' });
+        return;
+      }
+
+      showPopup({
+        title: `Delete "${profile.label}"?`,
+        message: 'This profile will be permanently removed. This action cannot be undone.',
+        positiveButton: {
+          text: 'Delete',
+          callback: async () => {
+            const wasActive = profile.id === activeProfileId;
+            const success = await removeProfile(profile.id);
+            if (success && wasActive) {
+              const newActive = await ProfileStorage.getActiveProfile();
+              if (newActive) {
+                ApiClient.setBaseUrl(newActive.serverUrl);
+              }
+            }
+          }
+        },
+        negativeButtonText: 'Cancel'
+      });
+    },
+    [profiles.length, activeProfileId, removeProfile]
+  );
+
+  const handleActivate = useCallback(
+    (profile: Profile) => {
+      showPopup({
+        title: `Switch to "${profile.label}"?`,
+        message: 'You will be connected to a different server and will need to log in again.',
+        positiveButton: {
+          text: 'Switch',
+          callback: async () => {
+            await setActive(profile.id);
+            ApiClient.setBaseUrl(profile.serverUrl);
+            dispatch({ type: LOGOUT_REQUEST_SUCCESS });
+            NavigationService.reset('Login');
+          }
+        },
+        negativeButtonText: 'Cancel'
+      });
+    },
+    [setActive, dispatch]
+  );
+
+  if (loading) {
+    return null;
+  }
+
+  return (
+    <ScrollView style={styles.container}>
+      <Card style={styles.card}>
+        <Card.Title
+          title="Profiles"
+          subtitle="Tap a profile to set it as active."
+          right={() => (
+            <IconButton
+              icon="plus"
+              color={Theme.colors.primary}
+              size={24}
+              style={styles.addIcon}
+              accessibilityLabel="Add profile"
+              onPress={openCreateDialog}
+            />
+          )}
+        />
+        <Card.Content>
+          {sortedProfiles.length === 0 ? (
+            <Paragraph>No profiles yet. Tap + to add one.</Paragraph>
+          ) : (
+            sortedProfiles.map((profile, index) => (
+              <ProfileRow
+                key={profile.id}
+                profile={profile}
+                isActive={profile.id === activeProfileId}
+                isLast={index === sortedProfiles.length - 1}
+                canDelete={profiles.length > 1}
+                onActivate={handleActivate}
+                onEdit={openEditDialog}
+                onDelete={handleDelete}
+              />
+            ))
+          )}
+        </Card.Content>
+      </Card>
+
+      <ProfileFormDialog
+        visible={dialogVisible}
+        profile={editingProfile}
+        onSave={handleSave}
+        onDismiss={dismissDialog}
+      />
+    </ScrollView>
+  );
+}
+
+const ProfileRow = memo(function ProfileRow({
+  profile,
+  isActive,
+  isLast,
+  canDelete,
+  onActivate,
+  onEdit,
+  onDelete
+}: ProfileRowProps) {
+  return (
+    <View style={[styles.profileRow, isLast && styles.profileRowLast, isActive && styles.profileRowActive]}>
+      <View style={isActive ? styles.activeIndicator : styles.inactiveIndicator} />
+      <TouchableOpacity
+        style={styles.profileTextContainer}
+        disabled={isActive}
+        activeOpacity={0.6}
+        onPress={() => onActivate(profile)}
+      >
+        <Paragraph style={styles.profileLabel}>{profile.label}</Paragraph>
+        <Caption numberOfLines={1}>{profile.serverUrl}</Caption>
+      </TouchableOpacity>
+      <View style={styles.profileActions}>
+        <IconButton
+          icon="pencil-outline"
+          color={Theme.colors.primary}
+          size={20}
+          style={styles.profileActionButton}
+          accessibilityLabel="Edit profile"
+          onPress={() => onEdit(profile)}
+        />
+        {canDelete && (
+          <IconButton
+            icon="delete-outline"
+            color={Theme.colors.danger}
+            size={20}
+            style={styles.profileActionButton}
+            accessibilityLabel="Delete profile"
+            onPress={() => onDelete(profile)}
+          />
+        )}
+      </View>
+    </View>
+  );
+});

--- a/src/screens/Profiles/styles.ts
+++ b/src/screens/Profiles/styles.ts
@@ -1,0 +1,111 @@
+import { StyleSheet } from 'react-native';
+import Theme from '../../utils/Theme';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: Theme.spacing.small
+  },
+  card: {
+    margin: Theme.spacing.small,
+    elevation: Theme.spacing.small / 2
+  },
+  addIcon: {
+    marginRight: Theme.spacing.small
+  },
+  profileRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Theme.spacing.medium,
+    borderBottomWidth: 1,
+    borderBottomColor: '#eee'
+  },
+  profileRowLast: {
+    borderBottomWidth: 0
+  },
+  profileRowActive: {
+    backgroundColor: '#f0f4f9'
+  },
+  activeIndicator: {
+    width: 3,
+    alignSelf: 'stretch',
+    backgroundColor: Theme.colors.primary,
+    borderRadius: 2,
+    marginRight: Theme.spacing.medium
+  },
+  inactiveIndicator: {
+    width: 3,
+    marginRight: Theme.spacing.medium
+  },
+  profileTextContainer: {
+    flex: 1
+  },
+  profileLabel: {
+    fontWeight: '600'
+  },
+  profileActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingRight: Theme.spacing.small
+  },
+  profileActionButton: {
+    margin: 0
+  },
+  // Dialog styles (matching AlternativeLocationSelector pattern)
+  modalOverlay: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)'
+  },
+  modalContent: {
+    width: '90%',
+    backgroundColor: 'white',
+    padding: Theme.spacing.large,
+    borderRadius: 8
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: '500',
+    color: Theme.colors.text,
+    marginBottom: 2
+  },
+  modalDescription: {
+    fontSize: 14,
+    marginBottom: Theme.spacing.large
+  },
+  input: {
+    marginBottom: Theme.spacing.medium,
+    backgroundColor: 'white'
+  },
+  errorBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#fdecea',
+    borderRadius: 4,
+    padding: Theme.spacing.medium,
+    marginBottom: Theme.spacing.medium
+  },
+  errorIcon: {
+    marginRight: Theme.spacing.small
+  },
+  errorText: {
+    color: '#d32f2f',
+    fontSize: 13,
+    flex: 1
+  },
+  dialogActions: {
+    flexDirection: 'row',
+    marginTop: Theme.spacing.large
+  },
+  dialogButtonLeft: {
+    flex: 1,
+    marginRight: Theme.spacing.small
+  },
+  dialogButtonRight: {
+    flex: 1,
+    marginLeft: Theme.spacing.small
+  }
+});
+
+export default styles;

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -1,5 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ScrollView } from 'react-native';
 import { Card, Paragraph, Text, TextInput } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -18,8 +17,6 @@ import {
   SettingsActionTypes
 } from '../../redux/actions/settings';
 import { RootState } from '../../redux/reducers';
-import ApiClient from '../../utils/ApiClient';
-import { environment } from '../../utils/Environment';
 import { DashboardEntry } from '../Dashboard/dashboardData';
 import { DashboardEntriesList } from '../Dashboard/DashboardEntriesList';
 import { ToggleCard } from '../Dashboard/ToggleCard';
@@ -27,38 +24,13 @@ import { ToggleRow } from '../Dashboard/ToggleRow';
 import { getProductSummaryConfig, ProductSummaryItem } from './productSummaryConfig';
 import styles from './styles';
 
-const API_URL_KEY = 'API_URL';
-
 const Settings = () => {
-  const [serverUrl, setServerUrl] = useState<string>('');
   const dispatch = useDispatch();
   const { groupLocationEntries, allowReallocationDuringPicking, productSummaryConfig, barcodeScanDebounceTime } =
     useSelector((state: RootState) => state.settingsReducer);
   const [debounceInput, setDebounceInput] = useState<string>(
     barcodeScanDebounceTime?.toString() ?? appConfig.DEFAULT_DEBOUNCE_TIME.toString()
   );
-
-  useEffect(() => {
-    AsyncStorage.getItem(API_URL_KEY)
-      .then((url) => {
-        setServerUrl(url ?? environment.API_BASE_URL);
-      })
-      .catch((err) => {
-        console.warn('Failed to load API_URL:', err);
-        setServerUrl(environment.API_BASE_URL);
-      });
-  }, []);
-
-  const handleServerUrlSave = useCallback(() => {
-    ApiClient.setBaseUrl(serverUrl);
-    AsyncStorage.setItem(API_URL_KEY, serverUrl)
-      .then(() => {
-        NavigationService.goBack();
-      })
-      .catch((err) => {
-        console.warn('Failed to save API_URL:', err);
-      });
-  }, [serverUrl]);
 
   const askResetDashboard = useCallback(() => {
     showPopup({
@@ -132,23 +104,19 @@ const Settings = () => {
 
   return (
     <ScrollView style={styles.container}>
-      {/* Server Connection */}
+      {/* Server Profiles */}
       <Card style={styles.card}>
-        <Card.Title title="Server Connection" />
+        <Card.Title title="Server Profiles" />
         <Card.Content>
           <Paragraph style={styles.paragraph}>
-            Set the server URL that will serve as the backend for the mobile application.
+            Manage server connection profiles. Switch between different servers at login.
           </Paragraph>
-          <TextInput
-            style={styles.input}
-            mode="outlined"
-            label="Server URL"
-            placeholder="http://localhost:8080/"
-            value={serverUrl}
-            autoCompleteType="off"
-            onChangeText={setServerUrl}
+          <Button
+            mode="contained"
+            size="100%"
+            title="Manage Profiles"
+            onPress={() => NavigationService.navigate('Profiles')}
           />
-          <Button mode="contained" size="100%" title="Save and Apply" onPress={handleServerUrlSave} />
         </Card.Content>
       </Card>
 

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,12 @@
+export type Profile = {
+  id: string;
+  label: string;
+  serverUrl: string;
+  settings: Record<string, unknown>;
+};
+
+export type ProfileStorageData = {
+  version: number;
+  activeProfileId: string | null;
+  profiles: Profile[];
+};

--- a/src/utils/ApiClient.ts
+++ b/src/utils/ApiClient.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 // import {logout} from '../redux/Dispatchers';
 import { createLogger } from './Logger';
-// import {environment} from './Environment';
 import * as NavigationService from '../NavigationService';
 import { store } from '../../App';
 import { hideScreenLoading } from '../redux/actions/main';

--- a/src/utils/Environment.ts
+++ b/src/utils/Environment.ts
@@ -1,7 +1,0 @@
-import { EnvironmentActual } from './EnvironmentActual';
-
-export interface Environment {
-  API_BASE_URL: string;
-}
-
-export const environment = EnvironmentActual;

--- a/src/utils/EnvironmentActual.ts
+++ b/src/utils/EnvironmentActual.ts
@@ -1,4 +1,0 @@
-import { Environment } from './Environment';
-export const EnvironmentActual: Environment = {
-  API_BASE_URL: 'https://vvg.openboxes.com/openboxes/api'
-};

--- a/src/utils/EventEmitter.ts
+++ b/src/utils/EventEmitter.ts
@@ -1,0 +1,15 @@
+type Listener = () => void;
+
+export function createEventEmitter() {
+  const listeners = new Set<Listener>();
+
+  return {
+    subscribe(listener: Listener): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    emit() {
+      listeners.forEach((fn) => fn());
+    }
+  };
+}


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-688

Changes:
  - Add server profiles system allowing users to create, edit, delete, and switch between multiple server connections
  - Display active profile on Login screen with skeleton loading state and tap-to-change navigation to Profiles management screen                                                 
  - Migrate existing API_URL from AsyncStorage into a "Default" profile on first boot after upgrade; default to Staging Server and Test Server profiles on fresh installs           
  - Replace Server Connection card in Settings with a "Manage Profiles" link
  - Log user out via API call (invalidating server session) and reset auth state when switching or deleting active profile                                                                               
  - Use versioned AsyncStorage schema for forward-compatible profile data                 
  - Initialize ApiClient when creating the first profile on a fresh install                
  - Normalize corrupted activeProfileId in migrate() by falling back to the first profile
  - Normalize URLs when deduplicating legacy API_URL against default server profiles      
  - Fix onSave typing in ProfileFormDialog to properly await and catch errors              
  - Fix saveProfile auto-activate to heal null activeProfileId regardless of profile count
  - Add error handling in useProfiles refresh to prevent infinite loading state            
  - Add reactive storage listener so profile changes propagate across screens without race
  conditions                                                                               
  - Reset navigation stack on logout so Login screen remounts with fresh state
  - Remove dead Environment.ts, EnvironmentActual.ts, and commented-out import


https://github.com/user-attachments/assets/3f6f9171-3bed-40f8-9770-631d933b18cc

