### PR TITLE
OBLS-635 Add native KeyboardModule for reliable soft keyboard control…

### DIFF
--- a/android/app/src/main/java/com/openboxes_mobile_o/KeyboardModule.java
+++ b/android/app/src/main/java/com/openboxes_mobile_o/KeyboardModule.java
@@ -50,14 +50,19 @@ public class KeyboardModule extends ReactContextBaseJavaModule {
                         }
                     });
                 } else {
-                    final ViewTreeObserver.OnWindowFocusChangeListener[] listenerHolder =
+                    final View.OnAttachStateChangeListener[] attachListenerHolder =
+                            new View.OnAttachStateChangeListener[1];
+                    final ViewTreeObserver.OnWindowFocusChangeListener[] focusListenerHolder =
                             new ViewTreeObserver.OnWindowFocusChangeListener[1];
 
-                    listenerHolder[0] = new ViewTreeObserver.OnWindowFocusChangeListener() {
+                    focusListenerHolder[0] = new ViewTreeObserver.OnWindowFocusChangeListener() {
                         @Override
                         public void onWindowFocusChanged(boolean hasFocus) {
-                            focusedView.getViewTreeObserver()
-                                    .removeOnWindowFocusChangeListener(this);
+                            ViewTreeObserver vto = focusedView.getViewTreeObserver();
+                            if (vto.isAlive()) {
+                                vto.removeOnWindowFocusChangeListener(this);
+                            }
+                            focusedView.removeOnAttachStateChangeListener(attachListenerHolder[0]);
                             if (hasFocus) {
                                 focusedView.post(new Runnable() {
                                     @Override
@@ -70,21 +75,23 @@ public class KeyboardModule extends ReactContextBaseJavaModule {
                         }
                     };
 
-                    focusedView.getViewTreeObserver().addOnWindowFocusChangeListener(listenerHolder[0]);
+                    // Clean up focus listener if the view is detached before window focus arrives
+                    attachListenerHolder[0] = new View.OnAttachStateChangeListener() {
+                        @Override
+                        public void onViewAttachedToWindow(View v) {}
 
-                    // Clean up listener if the view is detached before window focus arrives
-                    focusedView.addOnAttachStateChangeListener(
-                            new View.OnAttachStateChangeListener() {
-                                @Override
-                                public void onViewAttachedToWindow(View v) {}
+                        @Override
+                        public void onViewDetachedFromWindow(View v) {
+                            ViewTreeObserver vto = focusedView.getViewTreeObserver();
+                            if (vto.isAlive()) {
+                                vto.removeOnWindowFocusChangeListener(focusListenerHolder[0]);
+                            }
+                            focusedView.removeOnAttachStateChangeListener(this);
+                        }
+                    };
 
-                                @Override
-                                public void onViewDetachedFromWindow(View v) {
-                                    focusedView.getViewTreeObserver()
-                                            .removeOnWindowFocusChangeListener(listenerHolder[0]);
-                                    focusedView.removeOnAttachStateChangeListener(this);
-                                }
-                            });
+                    focusedView.getViewTreeObserver().addOnWindowFocusChangeListener(focusListenerHolder[0]);
+                    focusedView.addOnAttachStateChangeListener(attachListenerHolder[0]);
                 }
             }
         });

--- a/android/app/src/main/java/com/openboxes_mobile_o/KeyboardModule.java
+++ b/android/app/src/main/java/com/openboxes_mobile_o/KeyboardModule.java
@@ -1,0 +1,116 @@
+package com.openboxes.android;
+
+import android.app.Activity;
+import android.view.View;
+import android.view.ViewTreeObserver;
+import android.view.inputmethod.InputMethodManager;
+import android.content.Context;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+public class KeyboardModule extends ReactContextBaseJavaModule {
+
+    public KeyboardModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "KeyboardModule";
+    }
+
+    @ReactMethod
+    public void showKeyboard() {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final View focusedView = activity.getCurrentFocus();
+                if (focusedView == null) {
+                    return;
+                }
+
+                final InputMethodManager imm = (InputMethodManager)
+                        activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm == null) {
+                    return;
+                }
+
+                if (focusedView.hasWindowFocus()) {
+                    focusedView.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            imm.showSoftInput(focusedView, InputMethodManager.SHOW_IMPLICIT);
+                        }
+                    });
+                } else {
+                    final ViewTreeObserver.OnWindowFocusChangeListener[] listenerHolder =
+                            new ViewTreeObserver.OnWindowFocusChangeListener[1];
+
+                    listenerHolder[0] = new ViewTreeObserver.OnWindowFocusChangeListener() {
+                        @Override
+                        public void onWindowFocusChanged(boolean hasFocus) {
+                            focusedView.getViewTreeObserver()
+                                    .removeOnWindowFocusChangeListener(this);
+                            if (hasFocus) {
+                                focusedView.post(new Runnable() {
+                                    @Override
+                                    public void run() {
+                                        imm.showSoftInput(focusedView,
+                                                InputMethodManager.SHOW_IMPLICIT);
+                                    }
+                                });
+                            }
+                        }
+                    };
+
+                    focusedView.getViewTreeObserver().addOnWindowFocusChangeListener(listenerHolder[0]);
+
+                    // Clean up listener if the view is detached before window focus arrives
+                    focusedView.addOnAttachStateChangeListener(
+                            new View.OnAttachStateChangeListener() {
+                                @Override
+                                public void onViewAttachedToWindow(View v) {}
+
+                                @Override
+                                public void onViewDetachedFromWindow(View v) {
+                                    focusedView.getViewTreeObserver()
+                                            .removeOnWindowFocusChangeListener(listenerHolder[0]);
+                                    focusedView.removeOnAttachStateChangeListener(this);
+                                }
+                            });
+                }
+            }
+        });
+    }
+
+    @ReactMethod
+    public void hideKeyboard() {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+
+        activity.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                final View focusedView = activity.getCurrentFocus();
+                if (focusedView == null) {
+                    return;
+                }
+
+                final InputMethodManager imm = (InputMethodManager)
+                        activity.getSystemService(Context.INPUT_METHOD_SERVICE);
+                if (imm != null) {
+                    imm.hideSoftInputFromWindow(focusedView.getWindowToken(), 0);
+                }
+            }
+        });
+    }
+}

--- a/android/app/src/main/java/com/openboxes_mobile_o/KeyboardPackage.java
+++ b/android/app/src/main/java/com/openboxes_mobile_o/KeyboardPackage.java
@@ -1,0 +1,25 @@
+package com.openboxes.android;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class KeyboardPackage implements ReactPackage {
+
+    @Override
+    public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new KeyboardModule(reactContext));
+        return modules;
+    }
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+}

--- a/android/app/src/main/java/com/openboxes_mobile_o/MainApplication.java
+++ b/android/app/src/main/java/com/openboxes_mobile_o/MainApplication.java
@@ -28,8 +28,7 @@ public class MainApplication extends Application implements ReactApplication {
                 protected List<ReactPackage> getPackages() {
                     @SuppressWarnings("UnnecessaryLocalVariable")
                     List<ReactPackage> packages = new PackageList(this).getPackages();
-                    // Packages that cannot be autolinked yet can be added manually here, for example:
-                    // packages.add(new MyReactNativePackage());
+                    packages.add(new KeyboardPackage());
                     return packages;
                 }
 

--- a/src/components/ScannerInput.tsx
+++ b/src/components/ScannerInput.tsx
@@ -1,5 +1,5 @@
 import { useIsFocused } from '@react-navigation/native';
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AppState,
   InteractionManager,
@@ -14,10 +14,9 @@ import { useSelector } from 'react-redux';
 import { isString } from 'lodash';
 import { appConfig } from '../constants';
 import { RootState } from '../redux/reducers';
+import { hideSoftKeyboard, showSoftKeyboard } from '../utils/KeyboardUtils';
 import Theme from '../utils/Theme';
 import { KeyboardIcon, ScanIcon } from './Icons';
-
-const POST_TRANSITION_FOCUS_DELAY = 300;
 
 type ScannerInputProps = {
   value: string;
@@ -60,6 +59,9 @@ type ScannerInputProps = {
  *
  * This component is designed to work with hardware barcode scanners. It ensures that the input
  * is focused and ready for scanning. It also prevents the on-screen keyboard from appearing.
+ * Keyboard visibility is controlled explicitly via a native Android module (KeyboardModule)
+ * rather than the unreliable showSoftInputOnFocus prop.
+ *
  * IMPORTANT: Ensure there is one scanner input per screen.
  *
  * @example
@@ -70,196 +72,179 @@ type ScannerInputProps = {
  *   onSubmit={handleBarcodeSubmit}
  * />
  */
-export const ScannerInput = forwardRef<NativeTextInput, ScannerInputProps>(
-  (
-    {
-      value,
-      onChange,
-      onSubmit,
-      label,
-      style,
-      isEnabled = true,
-      autoSubmitTimeout,
-      leftIcon,
-      showKeyboardOnMount,
-      keyboardType,
-      placeholder,
-      danger = false
-    },
-    ref
-  ) => {
-    const storedDebounceTime = useSelector((state: RootState) => state.settingsReducer.barcodeScanDebounceTime);
-    const defaultTimeout = storedDebounceTime ?? appConfig.DEFAULT_DEBOUNCE_TIME;
-    const timeout = autoSubmitTimeout !== undefined ? autoSubmitTimeout : defaultTimeout;
-    const internalInputRef = useRef<NativeTextInput | null>(null);
-    const isScreenFocused = useIsFocused();
-    const [showKeyboard, setShowKeyboard] = useState(showKeyboardOnMount ?? false);
-    const formattedLabel = label && isString(label) ? label.toUpperCase() : 'SCAN BARCODE';
+export function ScannerInput({
+  value,
+  onChange,
+  onSubmit,
+  label,
+  style,
+  isEnabled = true,
+  autoSubmitTimeout,
+  leftIcon,
+  showKeyboardOnMount,
+  keyboardType,
+  placeholder,
+  danger = false
+}: ScannerInputProps) {
+  const storedDebounceTime = useSelector((state: RootState) => state.settingsReducer.barcodeScanDebounceTime);
+  const defaultTimeout = storedDebounceTime ?? appConfig.DEFAULT_DEBOUNCE_TIME;
+  const timeout = autoSubmitTimeout !== undefined ? autoSubmitTimeout : defaultTimeout;
+  const inputRef = useRef<NativeTextInput | null>(null);
+  const isScreenFocused = useIsFocused();
+  const [showKeyboard, setShowKeyboard] = useState(showKeyboardOnMount ?? false);
+  const formattedLabel = label && isString(label) ? label.toUpperCase() : 'SCAN BARCODE';
 
-    // Track the latest submitted value to prevent double submissions
-    const lastSubmittedValue = useRef<string>('');
-    const shouldBeFocused = isScreenFocused && isEnabled;
+  // Track the latest submitted value to prevent double submissions
+  const lastSubmittedValue = useRef<string>('');
+  const shouldBeFocused = isScreenFocused && isEnabled;
 
-    useImperativeHandle(ref, () => internalInputRef.current!);
+  // Focus the input — keyboard is handled via onFocus callback
+  const requestFocus = useCallback(() => {
+    if (!shouldBeFocused) {
+      return;
+    }
+    const input = inputRef.current;
+    if (input && !input.isFocused()) {
+      input.focus();
+    }
+  }, [shouldBeFocused]);
 
-    // Simple focus - just focus without all the complex logic
-    const requestFocus = useCallback(() => {
-      if (!shouldBeFocused) {
-        return;
-      }
-      const input = internalInputRef.current;
-      if (input && !input.isFocused()) {
-        input.focus();
-      }
-    }, [shouldBeFocused]);
+  // Focus on mount after navigation transitions complete
+  useEffect(() => {
+    if (shouldBeFocused) {
+      const handle = InteractionManager.runAfterInteractions(requestFocus);
+      return () => handle.cancel();
+    }
+  }, [requestFocus, shouldBeFocused]);
 
-    // Focus once on mount if the screen is focused, and whenever focus state changes
-    // Wait for navigation/animation transitions to complete, then delay slightly
-    // to ensure the native view has fully laid out before requesting focus
-    useEffect(() => {
-      if (shouldBeFocused) {
-        const handle = InteractionManager.runAfterInteractions(() => {
-          setTimeout(requestFocus, POST_TRANSITION_FOCUS_DELAY);
-        });
-        return () => handle.cancel();
-      }
-    }, [requestFocus, shouldBeFocused]);
-
-    // Handle app state changes
-    useEffect(() => {
-      const subscription = AppState.addEventListener('change', (nextAppState) => {
-        if (nextAppState === 'active' && shouldBeFocused) {
-          requestFocus();
-        }
-      });
-      return () => subscription.remove();
-    }, [requestFocus, shouldBeFocused]);
-
-    // Keyboard Dismissal (Hardware scanner often hides soft keyboard)
-    useEffect(() => {
-      if (!shouldBeFocused) {
-        return;
-      }
-      const hideSubscription = Keyboard.addListener('keyboardDidHide', requestFocus);
-      return () => hideSubscription.remove();
-    }, [requestFocus, shouldBeFocused]);
-
-    // Auto-submit after timeout
-    useEffect(() => {
-      // Don't auto-submit if disabled
-      if (!timeout) {
-        return;
-      }
-
-      // If the input is empty, reset last submitted value tracker
-      if (!value) {
-        lastSubmittedValue.current = '';
-        return;
-      }
-
-      // If the current value matches what we just submitted, don't trigger the timer again.
-      // This handles cases where parent component might not clear the input immediately after submit.
-      if (value === lastSubmittedValue.current) {
-        return;
-      }
-
-      const timer = setTimeout(() => {
-        const trimmed = value.trim();
-        if (trimmed && trimmed !== lastSubmittedValue.current) {
-          lastSubmittedValue.current = trimmed;
-          onSubmit(trimmed);
-        }
-      }, timeout);
-
-      return () => clearTimeout(timer);
-    }, [value, timeout, onSubmit]);
-
-    const handleBlur = () => {
-      if (shouldBeFocused) {
+  // Handle app state changes
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextAppState) => {
+      if (nextAppState === 'active' && shouldBeFocused) {
         requestFocus();
       }
-    };
+    });
+    return () => subscription.remove();
+  }, [requestFocus, shouldBeFocused]);
 
-    const handleChangeText = (text: string) => {
-      if (!shouldBeFocused) {
-        return;
-      }
-      onChange(text);
-    };
+  // Re-focus after hardware scanner dismisses keyboard (scanner mode only)
+  useEffect(() => {
+    if (!shouldBeFocused || showKeyboard) {
+      return;
+    }
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', requestFocus);
+    return () => hideSubscription.remove();
+  }, [requestFocus, shouldBeFocused, showKeyboard]);
 
-    const handleSubmitEditing = () => {
-      if (!shouldBeFocused) {
-        return;
-      }
+  // Auto-submit after timeout
+  useEffect(() => {
+    if (!timeout) {
+      return;
+    }
 
+    if (!value) {
+      lastSubmittedValue.current = '';
+      return;
+    }
+
+    if (value === lastSubmittedValue.current) {
+      return;
+    }
+
+    const timer = setTimeout(() => {
       const trimmed = value.trim();
-      if (trimmed) {
+      if (trimmed && trimmed !== lastSubmittedValue.current) {
         lastSubmittedValue.current = trimmed;
         onSubmit(trimmed);
       }
+    }, timeout);
 
+    return () => clearTimeout(timer);
+  }, [value, timeout, onSubmit]);
+
+  const handleFocus = useCallback(() => {
+    if (showKeyboard) {
+      showSoftKeyboard();
+    }
+  }, [showKeyboard]);
+
+  const handleBlur = () => {
+    if (shouldBeFocused && !showKeyboard) {
       requestFocus();
-    };
+    }
+  };
 
-    const handleKeyboardPress = () => {
-      setShowKeyboard((prevState) => {
-        const newShowKeyboard = !prevState;
+  const handleChangeText = (text: string) => {
+    if (!shouldBeFocused) {
+      return;
+    }
+    onChange(text);
+  };
 
-        if (newShowKeyboard) {
-          // Opening keyboard: blur and refocus to trigger showSoftInputOnFocus
-          // Add safety check here just in case ref was nulled out
-          const input = internalInputRef.current;
-          if (input) {
-            input.blur();
-            input.focus();
-          }
-        } else {
-          // Closing keyboard: just dismiss it
-          Keyboard.dismiss();
-        }
+  const handleSubmitEditing = () => {
+    if (!shouldBeFocused) {
+      return;
+    }
 
-        return newShowKeyboard;
-      });
-    };
+    const trimmed = value.trim();
+    if (trimmed) {
+      lastSubmittedValue.current = trimmed;
+      onSubmit(trimmed);
+    }
 
-    return (
-      <PaperTextInput
-        ref={internalInputRef}
-        mode="outlined"
-        label={formattedLabel}
-        value={value}
-        style={style}
-        // Keep keyboard hidden
-        showSoftInputOnFocus={showKeyboard}
-        autoCorrect={false}
-        autoCompleteType="off"
-        importantForAutofill="no"
-        placeholder={placeholder}
-        placeholderTextColor={danger ? Theme.colors.danger : Theme.colors.disabled}
-        blurOnSubmit={false}
-        returnKeyType="done"
-        keyboardType={keyboardType || 'default'}
-        error={danger}
-        left={
-          // @ts-ignore
-          <PaperTextInput.Icon
-            name={() => leftIcon || <ScanIcon size={24} color={danger ? Theme.colors.danger : undefined} />}
-          />
-        }
-        right={
-          // @ts-ignore
-          <PaperTextInput.Icon
-            name={() => <KeyboardIcon size={24} color={danger ? Theme.colors.danger : undefined} />}
-            onPress={handleKeyboardPress}
-          />
-        }
-        onBlur={handleBlur}
-        onFocus={() => {}}
-        onChangeText={handleChangeText}
-        onSubmitEditing={handleSubmitEditing}
-      />
-    );
-  }
-);
+    requestFocus();
+  };
+
+  const handleKeyboardPress = () => {
+    setShowKeyboard((prevState) => {
+      const newShowKeyboard = !prevState;
+
+      if (newShowKeyboard) {
+        showSoftKeyboard();
+      } else {
+        hideSoftKeyboard();
+      }
+
+      return newShowKeyboard;
+    });
+  };
+
+  return (
+    <PaperTextInput
+      ref={inputRef}
+      mode="outlined"
+      label={formattedLabel}
+      value={value}
+      style={style}
+      showSoftInputOnFocus={showKeyboard}
+      autoCorrect={false}
+      autoCompleteType="off"
+      importantForAutofill="no"
+      placeholder={placeholder}
+      placeholderTextColor={danger ? Theme.colors.danger : Theme.colors.disabled}
+      blurOnSubmit={false}
+      returnKeyType="done"
+      keyboardType={keyboardType || 'default'}
+      error={danger}
+      left={
+        // @ts-ignore
+        <PaperTextInput.Icon
+          name={() => leftIcon || <ScanIcon size={24} color={danger ? Theme.colors.danger : undefined} />}
+        />
+      }
+      right={
+        // @ts-ignore
+        <PaperTextInput.Icon
+          name={() => <KeyboardIcon size={24} color={danger ? Theme.colors.danger : undefined} />}
+          onPress={handleKeyboardPress}
+        />
+      }
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onChangeText={handleChangeText}
+      onSubmitEditing={handleSubmitEditing}
+    />
+  );
+}
 
 ScannerInput.displayName = 'ScannerInput';

--- a/src/components/ScannerInput.tsx
+++ b/src/components/ScannerInput.tsx
@@ -196,17 +196,18 @@ export function ScannerInput({
   };
 
   const handleKeyboardPress = () => {
-    setShowKeyboard((prevState) => {
-      const newShowKeyboard = !prevState;
+    const newShowKeyboard = !showKeyboard;
+    setShowKeyboard(newShowKeyboard);
 
-      if (newShowKeyboard) {
-        showSoftKeyboard();
-      } else {
-        hideSoftKeyboard();
+    if (newShowKeyboard) {
+      const input = inputRef.current;
+      if (input && !input.isFocused()) {
+        input.focus();
       }
-
-      return newShowKeyboard;
-    });
+      showSoftKeyboard();
+    } else {
+      hideSoftKeyboard();
+    }
   };
 
   return (

--- a/src/utils/KeyboardUtils.ts
+++ b/src/utils/KeyboardUtils.ts
@@ -1,4 +1,4 @@
-import { NativeModules, Platform } from 'react-native';
+import { Keyboard, NativeModules, Platform } from 'react-native';
 
 const { KeyboardModule } = NativeModules;
 
@@ -21,5 +21,7 @@ export function showSoftKeyboard(): void {
 export function hideSoftKeyboard(): void {
   if (Platform.OS === 'android' && KeyboardModule) {
     KeyboardModule.hideKeyboard();
+  } else {
+    Keyboard.dismiss();
   }
 }

--- a/src/utils/KeyboardUtils.ts
+++ b/src/utils/KeyboardUtils.ts
@@ -1,0 +1,25 @@
+import { NativeModules, Platform } from 'react-native';
+
+const { KeyboardModule } = NativeModules;
+
+/**
+ * Reliably shows the soft keyboard on Android by calling
+ * InputMethodManager.showSoftInput() directly via a native module.
+ *
+ * This bypasses the unreliable showSoftInputOnFocus prop behavior
+ * where focus() succeeds but the keyboard doesn't appear during
+ * navigation transitions.
+ *
+ * On iOS this is a no-op — focus() reliably shows the keyboard.
+ */
+export function showSoftKeyboard(): void {
+  if (Platform.OS === 'android' && KeyboardModule) {
+    KeyboardModule.showKeyboard();
+  }
+}
+
+export function hideSoftKeyboard(): void {
+  if (Platform.OS === 'android' && KeyboardModule) {
+    KeyboardModule.hideKeyboard();
+  }
+}


### PR DESCRIPTION
… on Android

https://openboxes.atlassian.net/browse/OBLS-635

Changes:
  - Add native Android KeyboardModule that calls InputMethodManager.showSoftInput() directly, bypassing the unreliable showSoftInputOnFocus prop behavior during navigation transitions                                                                              
  - The module waits for window focus via OnWindowFocusChangeListener before showing keyboard, with detach guards to prevent memory leaks                                     
  - Simplify ScannerInput component: remove unused forwardRef/useImperativeHandle, show keyboard via onFocus callback + native module, guard handleBlur and keyboardDidHide listener against keyboard mode                            
  - showSoftInputOnFocus prop now reflects showKeyboard state (preserves iOS behavior)