### PR TITLE
OBLS-370 Fix back navigation issues in picking flow

### DIFF
--- a/src/screens/Picking/PickingContext.tsx
+++ b/src/screens/Picking/PickingContext.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Alert } from 'react-native';
 import { useDispatch } from 'react-redux';
 
-import { navigate } from '../../NavigationService';
+import { navigate, resetToRoutes } from '../../NavigationService';
 import {
   dropPickTaskAction,
   getPickTaskByIdAction,
@@ -164,7 +164,10 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
           }
 
           Alert.alert('No Additional Tasks', 'No new pick tasks were created. Proceeding to staging location drop.', [
-            { text: 'OK', onPress: () => navigate('PickingPickStagingLocation') }
+            {
+              text: 'OK',
+              onPress: () => resetToRoutes([{ name: 'Dashboard' }, { name: 'PickingPickStagingLocation' }])
+            }
           ]);
           return;
         }

--- a/src/screens/Picking/PickingPickStagingLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickStagingLocationScreen.tsx
@@ -5,7 +5,7 @@ import { Divider, Paragraph, Subheading } from 'react-native-paper';
 import { ProductDetails } from '../../components/ProductDetails';
 import { ScannerInput } from '../../components/ScannerInput';
 import { EMPTY_STRING, HYPHEN } from '../../constants';
-import { navigate } from '../../NavigationService';
+import { resetToRoutes } from '../../NavigationService';
 import { usePickingContext } from './PickingContext';
 import styles from './styles';
 import { parseFromISODateToLocaleString } from '../../utils/utils';
@@ -28,7 +28,7 @@ export default function PickingPickStagingLocationScreen() {
     if (!currentTask) {
       // No tasks left at all, return to home
       Alert.alert('Staging', 'No more tasks available for staging drop.');
-      navigate('PickingPickType');
+      resetToRoutes([{ name: 'Dashboard' }, { name: 'PickingPickType' }]);
     }
   }, [currentTask, tasks.length, setCurrentTaskIndex, uniqueTasks.length, tasks]);
 
@@ -68,7 +68,7 @@ export default function PickingPickStagingLocationScreen() {
             text: 'OK',
             onPress: () => {
               resetSession();
-              navigate('PickingPickType');
+              resetToRoutes([{ name: 'Dashboard' }, { name: 'PickingPickType' }]);
             }
           }
         ]);

--- a/src/screens/Picking/lib.ts
+++ b/src/screens/Picking/lib.ts
@@ -39,7 +39,8 @@ export function revalidateTaskAndProceed(
     Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
       {
         text: 'OK',
-        onPress: () => resetToRoutes([{ name: 'PickingPickType' }, { name: 'PickingPickStagingLocation' }])
+        onPress: () =>
+          resetToRoutes([{ name: 'Dashboard' }, { name: 'PickingPickType' }, { name: 'PickingPickStagingLocation' }])
       }
     ]);
   });


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-370

Changes:                                                                         
  - `lib.ts` - "All Picks Complete" resets stack to `[Dashboard, PickingPickType, PickingPickStagingLocation]`.                            
  - `PickingContext.tsx` - short-pick "No Additional Tasks" branch resets to `[Dashboard, PickingPickStagingLocation]`.                                             
  - `PickingPickStagingLocationScreen.tsx` - both staging exit points reset to `[Dashboard, PickingPickType]` instead of bare `navigate`.