### PR TITLE
OBLS-703 Add confirm default bin location option on pick task with no…

### DIFF
--- a/src/screens/Picking/PickingPickLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickLocationScreen.tsx
@@ -24,17 +24,7 @@ export default function PickingPickLocationScreen() {
     return null;
   }
 
-  function handleScan(locationBarcode: string) {
-    const isValid = locationBarcode === currentTask?.location?.locationNumber;
-    if (!isValid) {
-      Alert.alert(
-        'Invalid Barcode',
-        `Incorrect location scanned. Expected: ${currentTask?.location?.locationNumber}. Try again.`,
-        [{ text: 'OK', onPress: () => setPickLocationBarcode(EMPTY_STRING) }]
-      );
-      return;
-    }
-
+  function proceedToProduct() {
     startPickTask(({ errorMessage }) => {
       if (errorMessage) {
         Alert.alert('Error', errorMessage);
@@ -43,10 +33,34 @@ export default function PickingPickLocationScreen() {
 
       revalidateCurrentTask(() => {
         setPickLocationBarcode(EMPTY_STRING);
-
         navigate('PickingPickProduct');
       });
     });
+  }
+
+  function handleScan(locationBarcode: string) {
+    if (!currentTask?.location?.locationNumber) {
+      Alert.alert(
+        'No Bin Location',
+        'There is no bin location assigned to this task. Do you want to continue and fallback to default?',
+        [
+          { text: 'Cancel', style: 'cancel', onPress: () => setPickLocationBarcode(EMPTY_STRING) },
+          { text: 'Continue', onPress: proceedToProduct }
+        ]
+      );
+      return;
+    }
+
+    if (locationBarcode !== currentTask.location.locationNumber) {
+      Alert.alert(
+        'Invalid Barcode',
+        `Incorrect location scanned. Expected: ${currentTask.location.locationNumber}. Try again.`,
+        [{ text: 'OK', onPress: () => setPickLocationBarcode(EMPTY_STRING) }]
+      );
+      return;
+    }
+
+    proceedToProduct();
   }
 
   return (

--- a/src/screens/Picking/PickingPickProductScreen.tsx
+++ b/src/screens/Picking/PickingPickProductScreen.tsx
@@ -73,7 +73,7 @@ export default function PickingPickProductScreen() {
               label: 'Quantity Picked',
               value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`
             },
-            { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || HYPHEN }
+            { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || 'Default' }
           ]}
         />
       </ProductDetails.Root>

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -148,7 +148,7 @@ export default function PickingPickQuantityScreen() {
                 label: 'Quantity Picked',
                 value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`
               },
-              { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || HYPHEN }
+              { icon: 'pin', label: 'Pick Location', value: currentTask.location?.name || 'Default' }
             ]}
           />
         </ProductDetails.Root>


### PR DESCRIPTION
… bin assigned

  Changes:                                                  
  - `PickingPickLocationScreen.tsx` - when location is null, prompt user with a confirmation alert to continue with default instead of showing an invalid barcode error.                                                              
  - `PickingPickProductScreen.tsx`, `PickingPickQuantityScreen.tsx` - show "Default" instead of "-" for Pick Location when bin is null.
 
<img width="370" height="593" alt="image" src="https://github.com/user-attachments/assets/44ae95e3-aa0c-49dd-84e5-996a838c5220" />

