### PR TITLE
OBLS-661 Add built info label to Login, Dashboard, Settings and Drawe…

### DIFF
--- a/src/components/BuildInfoLabel.tsx
+++ b/src/components/BuildInfoLabel.tsx
@@ -1,0 +1,31 @@
+import { BUILD_NUMBER } from '@env';
+import React from 'react';
+import { StyleProp, StyleSheet, Text, TextStyle } from 'react-native';
+import DeviceInfo from 'react-native-device-info';
+import Theme from '../utils/Theme';
+
+type BuildInfoLabelProps = {
+  style?: StyleProp<TextStyle>;
+};
+
+const BuildInfoLabel = ({ style }: BuildInfoLabelProps) => {
+  const version = DeviceInfo.getVersion();
+  const build = BUILD_NUMBER || 'Development';
+
+  return (
+    <Text style={[styles.label, style]}>
+      OpenBoxes {version} (Build: {build})
+    </Text>
+  );
+};
+
+const styles = StyleSheet.create({
+  label: {
+    fontSize: 12,
+    color: Theme.colors.placeholder,
+    textAlign: 'center',
+    paddingVertical: Theme.spacing.small
+  }
+});
+
+export default BuildInfoLabel;

--- a/src/components/CustomDrawerContent/CustomDrawerContent.tsx
+++ b/src/components/CustomDrawerContent/CustomDrawerContent.tsx
@@ -4,6 +4,7 @@ import { View } from 'react-native';
 import { Button, Caption, Paragraph } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
+import BuildInfoLabel from '../BuildInfoLabel';
 import * as NavigationService from '../../NavigationService';
 import { logout } from '../../redux/actions/auth';
 import { RootState } from '../../redux/reducers';
@@ -54,6 +55,7 @@ const CustomDrawerContent = (props: DrawerContentComponentProps) => {
         >
           Logout
         </Button>
+        <BuildInfoLabel style={{ paddingBottom: 0 }} />
       </View>
     </DrawerContentScrollView>
   );

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo } from 'react';
 import { FlatList, ListRenderItemInfo, ScrollView, Text, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
+import BuildInfoLabel from '../../components/BuildInfoLabel';
 import EmptyIcon from '../../assets/images/icon_empty.svg';
 import Button from '../../components/Button';
 import { useFilteredDashboardEntries } from '../../hooks/useFilteredDashboardEntries';
@@ -97,6 +98,7 @@ export default function Dashboard({ navigation }: Props) {
       {GROUP_ORDER.map((group) => (
         <DashboardGroupSection key={group} group={group} entries={groupedEntries[group]} columns={columns} />
       ))}
+      <BuildInfoLabel />
     </ScrollView>
   );
 }

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -5,6 +5,7 @@ import { Caption, Paragraph, TextInput } from 'react-native-paper';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useDispatch } from 'react-redux';
 import ProfileCardSkeleton from '../../components/ProfileCardSkeleton';
+import BuildInfoLabel from '../../components/BuildInfoLabel';
 import EyeIcon from '../../assets/images/icon_eye.svg';
 import EyeSlashIcon from '../../assets/images/icon_eye_slash.svg';
 import Button from '../../components/Button';
@@ -76,67 +77,70 @@ const Login = () => {
   };
 
   return (
-    <ScrollView style={styles.screenContainer} contentContainerStyle={{ flexGrow: 1, justifyContent: 'center' }}>
-      <View style={styles.welcomeContainer}>
-        <Image source={require('../../assets/images/logo.png')} style={styles.logo} resizeMode="contain" />
-      </View>
-      {loading ? (
-        <ProfileCardSkeleton />
-      ) : activeProfile ? (
-        <TouchableOpacity
-          style={styles.profileCard}
-          activeOpacity={0.7}
-          onPress={() => NavigationService.navigate('Profiles')}
-        >
-          <View style={styles.profileCardOuter}>
-            <View style={styles.profileCardInner}>
-              <Caption style={styles.profileCardTitle}>CONNECTED TO</Caption>
-              <View style={styles.profileCardContent}>
-                <Icon name="server" size={22} color={Theme.colors.primary} style={styles.profileCardServerIcon} />
-                <View style={styles.profileCardText}>
-                  <Paragraph style={styles.profileCardLabel}>{activeProfile.label}</Paragraph>
-                  <Caption style={styles.profileCardUrl} numberOfLines={1}>
-                    {activeProfile.serverUrl}
-                  </Caption>
+    <ScrollView style={styles.screenContainer} contentContainerStyle={{ flexGrow: 1 }}>
+      <View style={{ flex: 1, justifyContent: 'center' }}>
+        <View style={styles.welcomeContainer}>
+          <Image source={require('../../assets/images/logo.png')} style={styles.logo} resizeMode="contain" />
+        </View>
+        {loading ? (
+          <ProfileCardSkeleton />
+        ) : activeProfile ? (
+          <TouchableOpacity
+            style={styles.profileCard}
+            activeOpacity={0.7}
+            onPress={() => NavigationService.navigate('Profiles')}
+          >
+            <View style={styles.profileCardOuter}>
+              <View style={styles.profileCardInner}>
+                <Caption style={styles.profileCardTitle}>CONNECTED TO</Caption>
+                <View style={styles.profileCardContent}>
+                  <Icon name="server" size={22} color={Theme.colors.primary} style={styles.profileCardServerIcon} />
+                  <View style={styles.profileCardText}>
+                    <Paragraph style={styles.profileCardLabel}>{activeProfile.label}</Paragraph>
+                    <Caption style={styles.profileCardUrl} numberOfLines={1}>
+                      {activeProfile.serverUrl}
+                    </Caption>
+                  </View>
                 </View>
               </View>
+              <Icon name="chevron-right" size={20} color={Theme.colors.disabled} />
             </View>
-            <Icon name="chevron-right" size={20} color={Theme.colors.disabled} />
-          </View>
-        </TouchableOpacity>
-      ) : null}
-      <View style={styles.inputsContainer}>
-        <TextInput mode="flat" label={'Username'} placeholder="Username" onChangeText={onUsernameChange} />
-        <TextInput
-          mode="flat"
-          placeholder="Password"
-          label={'Password'}
-          secureTextEntry={state.isSeePassword}
-          right={
-            <TextInput.Icon
-              icon={() =>
-                state.isSeePassword ? <EyeIcon width={24} height={24} /> : <EyeSlashIcon width={24} height={24} />
-              }
-              onPress={onPasswordClick}
-            />
-          }
-          style={{
-            marginTop: Theme.spacing.small
-          }}
-          onChangeText={onPasswordChange}
-        />
+          </TouchableOpacity>
+        ) : null}
+        <View style={styles.inputsContainer}>
+          <TextInput mode="flat" label={'Username'} placeholder="Username" onChangeText={onUsernameChange} />
+          <TextInput
+            mode="flat"
+            placeholder="Password"
+            label={'Password'}
+            secureTextEntry={state.isSeePassword}
+            right={
+              <TextInput.Icon
+                icon={() =>
+                  state.isSeePassword ? <EyeIcon width={24} height={24} /> : <EyeSlashIcon width={24} height={24} />
+                }
+                onPress={onPasswordClick}
+              />
+            }
+            style={{
+              marginTop: Theme.spacing.small
+            }}
+            onChangeText={onPasswordChange}
+          />
+        </View>
+        <View style={styles.buttonsContainer}>
+          <Button title="Login" size="100%" style={{ marginBottom: 8 }} onPress={onLoginPress} />
+          <Button
+            title="Settings"
+            size="100%"
+            mode="text"
+            onPress={() => {
+              NavigationService.navigate('Settings');
+            }}
+          />
+        </View>
       </View>
-      <View style={styles.buttonsContainer}>
-        <Button title="Login" size="100%" style={{ marginBottom: 8 }} onPress={onLoginPress} />
-        <Button
-          title="Settings"
-          size="100%"
-          mode="text"
-          onPress={() => {
-            NavigationService.navigate('Settings');
-          }}
-        />
-      </View>
+      <BuildInfoLabel />
     </ScrollView>
   );
 };

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -3,6 +3,7 @@ import { ScrollView } from 'react-native';
 import { Card, Paragraph, Text, TextInput } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
+import BuildInfoLabel from '../../components/BuildInfoLabel';
 import Button from '../../components/Button';
 import showPopup from '../../components/Popup';
 import { appConfig } from '../../constants';
@@ -175,6 +176,7 @@ const Settings = () => {
           />
         ))}
       </ToggleCard>
+      <BuildInfoLabel style={{ paddingBottom: 16 }} />
     </ScrollView>
   );
 };


### PR DESCRIPTION
…r screens

https://openboxes.atlassian.net/browse/OBLS-661

Changes:
  - Created reusable BuildInfoLabel component that displays `OpenBoxes {version} (Build: {buildNumber})` (falls back to "Development")
  - Added the label to four screens: Login (pinned to bottom), Dashboard (below group sections), Settings (below last card), and Drawer sidebar (below Logout button)

<img width="247" height="123" alt="image" src="https://github.com/user-attachments/assets/ebbe0498-073c-4443-98a9-78fdd6634c29" />
<img width="370" height="181" alt="image" src="https://github.com/user-attachments/assets/defa1c0a-d3cc-4284-9fba-af5c648ff98f" />
<img width="370" height="181" alt="image" src="https://github.com/user-attachments/assets/db1b7ce6-4851-4d17-9ba4-eb169a1c6304" />
<img width="370" height="181" alt="image" src="https://github.com/user-attachments/assets/5c027259-1958-4098-a5b9-00210579f2de" />

