### PR TITLE
OBLS-717 Search debounce adjustments

### DIFF
--- a/src/components/AsyncModalSelect/index.tsx
+++ b/src/components/AsyncModalSelect/index.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Image, TextInput, TouchableOpacity, View } from 'react-native';
 import { useDispatch } from 'react-redux';
 
@@ -56,7 +56,9 @@ const AsyncModalSelect = ({
     onSelect?.({ id: '', name: '' });
   };
 
-  const debounceOnSearchTerm = _.debounce((term: string) => setSearchTerm(term), appConfig.DEFAULT_DEBOUNCE_TIME);
+  const debounceOnSearchTerm = useRef(
+    _.debounce((term: string) => setSearchTerm(term), appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
+  ).current;
 
   return (
     <View style={styles.mainContainer}>

--- a/src/components/BarcodeSearchHeader/BarcodeSearchHeader.tsx
+++ b/src/components/BarcodeSearchHeader/BarcodeSearchHeader.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
 import { useNavigation } from '@react-navigation/native';
-import { Searchbar } from 'react-native-paper';
-import styles from './styles';
+import _ from 'lodash';
+import React, { useEffect, useRef, useState } from 'react';
 import { View } from 'react-native';
-import Theme from '../../utils/Theme';
+import { Searchbar } from 'react-native-paper';
+import { appConfig } from '../../constants';
+import styles from './styles';
 
 interface OwnProps {
   subtitle?: string | null;
@@ -11,8 +12,8 @@ interface OwnProps {
   searchBox: boolean;
   onSearchTermSubmit: (query: string) => void;
   resetSearch?: () => void;
-  autoSearch: boolean | false;
-  autoFocus?: boolean | false;
+  autoSearch: boolean;
+  autoFocus?: boolean;
 }
 
 const BarcodeSearchHeader: React.FC<OwnProps> = (props) => {
@@ -20,12 +21,24 @@ const BarcodeSearchHeader: React.FC<OwnProps> = (props) => {
 
   const navigation = useNavigation<any>();
 
+  const onSearchTermSubmitRef = useRef(props.onSearchTermSubmit);
+  onSearchTermSubmitRef.current = props.onSearchTermSubmit;
+
+  const debouncedSearchTermSubmit = useRef(
+    _.debounce((term: string) => onSearchTermSubmitRef.current(term), appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
+  ).current;
+
   // If autoSearch is true, then trigger onSearchTermSubmit on a searchTerm change
   useEffect(() => {
     if (props.autoSearch) {
-      onSearchTermSubmit();
+      debouncedSearchTermSubmit(searchTerm);
     }
-  }, [searchTerm]);
+  }, [debouncedSearchTermSubmit, props.autoSearch, searchTerm]);
+
+  // Cancel pending debounced calls on unmount
+  useEffect(() => {
+    return () => debouncedSearchTermSubmit.cancel();
+  }, [debouncedSearchTermSubmit]);
 
   // Resets the search bar's search term on the navigation change
   useEffect(() => {
@@ -35,7 +48,8 @@ const BarcodeSearchHeader: React.FC<OwnProps> = (props) => {
         props.resetSearch();
       }
     });
-  }, [navigation]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [navigation, props.resetSearch]);
 
   const onSearchTermSubmit = () => {
     props.onSearchTermSubmit(searchTerm);


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-717

Changes:                                                                          
  - Fix search debounce in `BarcodeSearchHeader` and `AsyncModalSelect` - both were using  
    `DEFAULT_DEBOUNCE_TIME` (100ms) instead of `DEFAULT_SEARCH_DEBOUNCE_TIME` (800ms), causing excessive API calls and re-renders on every keystroke                          
  - Stabilize debounced functions with `useRef` to persist across re-renders
  - Add cleanup on unmount to cancel pending debounced calls