### PR TITLE
OBLS-278 Add configurable search debounce

### DIFF
--- a/src/components/AsyncModalSelect/index.tsx
+++ b/src/components/AsyncModalSelect/index.tsx
@@ -64,6 +64,10 @@ const AsyncModalSelect = ({
     [searchDebounceTime]
   );
 
+  useEffect(() => {
+    return () => debounceOnSearchTerm.cancel();
+  }, [debounceOnSearchTerm]);
+
   return (
     <View style={styles.mainContainer}>
       <View style={styles.inputContainer}>

--- a/src/components/AsyncModalSelect/index.tsx
+++ b/src/components/AsyncModalSelect/index.tsx
@@ -1,11 +1,12 @@
 import _ from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Image, TextInput, TouchableOpacity, View } from 'react-native';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import ModalSelector from 'react-native-modal-selector-searchable';
 import CLEAR from '../../assets/images/icon_clear.png';
 import { appConfig } from '../../constants';
+import { RootState } from '../../redux/reducers';
 import showPopup from '../Popup';
 import styles from './styles';
 import { Props } from './types';
@@ -23,6 +24,7 @@ const AsyncModalSelect = ({
   const [data, setData] = useState<any[]>([]);
   const [searchTerm, setSearchTerm] = useState<string>('');
   const dispatch = useDispatch();
+  const searchDebounceTime = useSelector((state: RootState) => state.settingsReducer.searchDebounceTime);
 
   useEffect(() => {
     if (searchTerm) {
@@ -56,9 +58,11 @@ const AsyncModalSelect = ({
     onSelect?.({ id: '', name: '' });
   };
 
-  const debounceOnSearchTerm = useRef(
-    _.debounce((term: string) => setSearchTerm(term), appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
-  ).current;
+  const debounceOnSearchTerm = useMemo(
+    () =>
+      _.debounce((term: string) => setSearchTerm(term), searchDebounceTime ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME),
+    [searchDebounceTime]
+  );
 
   return (
     <View style={styles.mainContainer}>

--- a/src/components/BarcodeSearchHeader/BarcodeSearchHeader.tsx
+++ b/src/components/BarcodeSearchHeader/BarcodeSearchHeader.tsx
@@ -1,9 +1,12 @@
 import { useNavigation } from '@react-navigation/native';
 import _ from 'lodash';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View } from 'react-native';
 import { Searchbar } from 'react-native-paper';
+import { useSelector } from 'react-redux';
+
 import { appConfig } from '../../constants';
+import { RootState } from '../../redux/reducers';
 import styles from './styles';
 
 interface OwnProps {
@@ -14,33 +17,41 @@ interface OwnProps {
   resetSearch?: () => void;
   autoSearch: boolean;
   autoFocus?: boolean;
+  /**
+   * Override the debounce time (in ms) applied when autoSearch is enabled.
+   * Defaults to the `searchDebounceTime` from settings, or DEFAULT_SEARCH_DEBOUNCE_TIME.
+   */
+  debounceTime?: number;
 }
 
 const BarcodeSearchHeader: React.FC<OwnProps> = (props) => {
   const [searchTerm, setSearchTerm] = useState<string>('');
-
   const navigation = useNavigation<any>();
+  const storedDebounceTime = useSelector(
+    (state: RootState) => state.settingsReducer.searchDebounceTime ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME
+  );
+  const searchDebounceTime = props.debounceTime !== undefined ? props.debounceTime : storedDebounceTime;
 
-  const onSearchTermSubmitRef = useRef(props.onSearchTermSubmit);
-  onSearchTermSubmitRef.current = props.onSearchTermSubmit;
+  const onSubmitRef = useRef(props.onSearchTermSubmit);
+  useEffect(() => {
+    onSubmitRef.current = props.onSearchTermSubmit;
+  }, [props.onSearchTermSubmit]);
 
-  const debouncedSearchTermSubmit = useRef(
-    _.debounce((term: string) => onSearchTermSubmitRef.current(term), appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
-  ).current;
+  const debouncedSubmit = useMemo(
+    () => _.debounce((query: string) => onSubmitRef.current(query), searchDebounceTime),
+    [searchDebounceTime]
+  );
 
-  // If autoSearch is true, then trigger onSearchTermSubmit on a searchTerm change
+  useEffect(() => {
+    return () => debouncedSubmit.cancel();
+  }, [debouncedSubmit]);
+
   useEffect(() => {
     if (props.autoSearch) {
-      debouncedSearchTermSubmit(searchTerm);
+      debouncedSubmit(searchTerm);
     }
-  }, [debouncedSearchTermSubmit, props.autoSearch, searchTerm]);
+  }, [searchTerm, props.autoSearch, debouncedSubmit]);
 
-  // Cancel pending debounced calls on unmount
-  useEffect(() => {
-    return () => debouncedSearchTermSubmit.cancel();
-  }, [debouncedSearchTermSubmit]);
-
-  // Resets the search bar's search term on the navigation change
   useEffect(() => {
     return navigation.addListener('focus', () => {
       setSearchTerm('');
@@ -52,12 +63,14 @@ const BarcodeSearchHeader: React.FC<OwnProps> = (props) => {
   }, [navigation, props.resetSearch]);
 
   const onSearchTermSubmit = () => {
+    debouncedSubmit.cancel();
     props.onSearchTermSubmit(searchTerm);
   };
 
   return (
     <View style={styles.container}>
       <Searchbar
+        autoCompleteType="off"
         theme={{}}
         placeholder={props.placeholder ? props.placeholder : 'Search...'}
         value={searchTerm}

--- a/src/components/SearchButton/index.tsx
+++ b/src/components/SearchButton/index.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, FlatList, Modal, Text, TouchableOpacity, View } from 'react-native';
 import { TextInput as PaperTextInput } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
@@ -54,9 +54,23 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
     );
   };
 
-  const debouncedSearch = useRef(
-    _.debounce((term: string) => performSearch(term), searchDebounceTime ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
-  ).current;
+  const performSearchRef = useRef(performSearch);
+  useEffect(() => {
+    performSearchRef.current = performSearch;
+  });
+
+  const debouncedSearch = useMemo(
+    () =>
+      _.debounce(
+        (term: string) => performSearchRef.current(term),
+        searchDebounceTime ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME
+      ),
+    [searchDebounceTime]
+  );
+
+  useEffect(() => {
+    return () => debouncedSearch.cancel();
+  }, [debouncedSearch]);
 
   const handleChangeText = (text: string) => {
     setSearchTerm(text);

--- a/src/components/SearchButton/index.tsx
+++ b/src/components/SearchButton/index.tsx
@@ -3,9 +3,10 @@ import React, { useRef, useState } from 'react';
 import { Alert, FlatList, Modal, Text, TouchableOpacity, View } from 'react-native';
 import { TextInput as PaperTextInput } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { appConfig } from '../../constants';
+import { RootState } from '../../redux/reducers';
 import Theme from '../../utils/Theme';
 import { SkeletonList } from './SkeletonList';
 import { SearchResult, SearchType, searchProviders } from './searchProviders';
@@ -25,6 +26,7 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
   const [loading, setLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const dispatch = useDispatch();
+  const searchDebounceTime = useSelector((state: RootState) => state.settingsReducer.searchDebounceTime);
   const provider = searchProviders[searchType];
 
   const performSearch = (term: string) => {
@@ -53,7 +55,7 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
   };
 
   const debouncedSearch = useRef(
-    _.debounce((term: string) => performSearch(term), appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
+    _.debounce((term: string) => performSearch(term), searchDebounceTime ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME)
   ).current;
 
   const handleChangeText = (text: string) => {

--- a/src/redux/actions/settings.ts
+++ b/src/redux/actions/settings.ts
@@ -4,6 +4,7 @@ export const DASHBOARD_ENTRIES_ORDER = 'DASHBOARD_ENTRIES_ORDER';
 export const GROUP_LOCATION_ENTRIES = 'GROUP_LOCATION_ENTRIES';
 export const PRODUCT_SUMMARY_CONFIG = 'PRODUCT_SUMMARY_CONFIG';
 export const BARCODE_SCAN_DEBOUNCE = 'BARCODE_SCAN_DEBOUNCE';
+export const SEARCH_DEBOUNCE = 'SEARCH_DEBOUNCE';
 export const ALLOW_REALLOCATION_DURING_PICKING = 'ALLOW_REALLOCATION_DURING_PICKING';
 
 type SetAllowReallocationDuringPickingAction = {
@@ -44,6 +45,11 @@ type SetBarcodeScanDebounceAction = {
   payload: number;
 };
 
+type SetSearchDebounceAction = {
+  type: typeof SEARCH_DEBOUNCE;
+  payload: number;
+};
+
 // Create a union type for all action types in this file.
 // e.g., export type SettingsActionTypes = SetGroupLocationEntriesAction | SetThemeAction;
 export type SettingsActionTypes =
@@ -53,6 +59,7 @@ export type SettingsActionTypes =
   | SetDashboardEntriesOrderAction
   | SetProductSummaryConfigAction
   | SetBarcodeScanDebounceAction
+  | SetSearchDebounceAction
   | SetAllowReallocationDuringPickingAction;
 
 export const setGroupLocationEntries = (group: boolean): SetGroupLocationEntriesAction => {
@@ -95,6 +102,13 @@ export const setProductSummaryConfig = (key: string, visible: boolean): SetProdu
 export const setBarcodeScanDebounce = (value: number): SetBarcodeScanDebounceAction => {
   return {
     type: BARCODE_SCAN_DEBOUNCE,
+    payload: value
+  };
+};
+
+export const setSearchDebounce = (value: number): SetSearchDebounceAction => {
+  return {
+    type: SEARCH_DEBOUNCE,
     payload: value
   };
 };

--- a/src/redux/reducers/settingsReducer.ts
+++ b/src/redux/reducers/settingsReducer.ts
@@ -6,6 +6,7 @@ import {
   GROUP_LOCATION_ENTRIES,
   PRODUCT_SUMMARY_CONFIG,
   BARCODE_SCAN_DEBOUNCE,
+  SEARCH_DEBOUNCE,
   SettingsActionTypes,
   ALLOW_REALLOCATION_DURING_PICKING
 } from '../actions/settings';
@@ -18,6 +19,7 @@ type SettingsState = {
   dashboardEntriesOrder: string[];
   productSummaryConfig: { [key: string]: boolean };
   barcodeScanDebounceTime: number;
+  searchDebounceTime: number;
 };
 
 const initialState: SettingsState = {
@@ -26,7 +28,8 @@ const initialState: SettingsState = {
   dashboardEntriesOrder: getDashboardEntriesKeys(),
   dashboardEntriesVisibility: {},
   productSummaryConfig: {},
-  barcodeScanDebounceTime: appConfig.DEFAULT_DEBOUNCE_TIME
+  barcodeScanDebounceTime: appConfig.DEFAULT_DEBOUNCE_TIME,
+  searchDebounceTime: appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME
 };
 
 function settingsReducer(state = initialState, action: SettingsActionTypes): SettingsState {
@@ -79,6 +82,11 @@ function settingsReducer(state = initialState, action: SettingsActionTypes): Set
       return {
         ...state,
         barcodeScanDebounceTime: action.payload
+      };
+    case SEARCH_DEBOUNCE:
+      return {
+        ...state,
+        searchDebounceTime: action.payload
       };
     default: {
       return state;

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -15,6 +15,7 @@ import {
   setDashboardEntriesOrder,
   setGroupLocationEntries,
   setProductSummaryConfig,
+  setSearchDebounce,
   SettingsActionTypes
 } from '../../redux/actions/settings';
 import { RootState } from '../../redux/reducers';
@@ -27,10 +28,18 @@ import styles from './styles';
 
 const Settings = () => {
   const dispatch = useDispatch();
-  const { groupLocationEntries, allowReallocationDuringPicking, productSummaryConfig, barcodeScanDebounceTime } =
-    useSelector((state: RootState) => state.settingsReducer);
+  const {
+    groupLocationEntries,
+    allowReallocationDuringPicking,
+    productSummaryConfig,
+    barcodeScanDebounceTime,
+    searchDebounceTime
+  } = useSelector((state: RootState) => state.settingsReducer);
   const [debounceInput, setDebounceInput] = useState<string>(
     barcodeScanDebounceTime?.toString() ?? appConfig.DEFAULT_DEBOUNCE_TIME.toString()
+  );
+  const [searchDebounceInput, setSearchDebounceInput] = useState<string>(
+    searchDebounceTime?.toString() ?? appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME.toString()
   );
 
   const askResetDashboard = useCallback(() => {
@@ -68,15 +77,42 @@ const Settings = () => {
     [dispatch]
   );
 
-  const askResetDebounce = useCallback(() => {
+  const handleSearchDebounceChange = useCallback(
+    (text: string) => {
+      const numericValue = text.replace(/[^0-9]/g, '');
+      setSearchDebounceInput(numericValue);
+      const value = parseInt(numericValue, 10);
+      if (!isNaN(value) && value >= 0) {
+        dispatch(setSearchDebounce(value));
+      }
+    },
+    [dispatch]
+  );
+
+  const askResetScanDebounce = useCallback(() => {
     showPopup({
       title: 'Reset Scanning Debounce',
-      message: `Are you sure you want to reset scanning debounce to default (${appConfig.DEFAULT_DEBOUNCE_TIME}ms)?`,
+      message: `Reset scanning debounce to default (${appConfig.DEFAULT_DEBOUNCE_TIME}ms)?`,
       positiveButton: {
         text: 'Reset',
         callback: () => {
           dispatch(setBarcodeScanDebounce(appConfig.DEFAULT_DEBOUNCE_TIME));
           setDebounceInput(appConfig.DEFAULT_DEBOUNCE_TIME.toString());
+        }
+      },
+      negativeButtonText: 'Cancel'
+    });
+  }, [dispatch]);
+
+  const askResetSearchDebounce = useCallback(() => {
+    showPopup({
+      title: 'Reset Search Debounce',
+      message: `Reset search debounce to default (${appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME}ms)?`,
+      positiveButton: {
+        text: 'Reset',
+        callback: () => {
+          dispatch(setSearchDebounce(appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME));
+          setSearchDebounceInput(appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME.toString());
         }
       },
       negativeButtonText: 'Cancel'
@@ -137,9 +173,8 @@ const Settings = () => {
         />
       </ToggleCard>
 
-      {/* Scanner Settings */}
-      <ToggleCard title="Scanner Settings">
-        <Paragraph style={styles.paragraph}>Configure barcode scanner behavior.</Paragraph>
+      {/* Debounce Settings */}
+      <ToggleCard title="Debounce Settings" subtitle="Configure debounce timings for scanning and search.">
         <TextInput
           autoCompleteType="off"
           style={styles.input}
@@ -151,11 +186,35 @@ const Settings = () => {
           onChangeText={handleDebounceChange}
         />
         <Paragraph style={styles.paragraphSmall}>
-          Time in milliseconds to wait after scanning before auto-submitting.{' '}
+          Time in milliseconds to wait after scanning before auto-submitting.
           {barcodeScanDebounceTime !== undefined && barcodeScanDebounceTime !== appConfig.DEFAULT_DEBOUNCE_TIME && (
-            <Text style={styles.link} onPress={askResetDebounce}>
-              Reset to default.
-            </Text>
+            <>
+              {' '}
+              <Text style={styles.link} onPress={askResetScanDebounce}>
+                Reset to default.
+              </Text>
+            </>
+          )}
+        </Paragraph>
+        <TextInput
+          autoCompleteType="off"
+          style={styles.input}
+          mode="outlined"
+          label="Search Debounce [ms]"
+          placeholder="e.g., 800"
+          value={searchDebounceInput}
+          keyboardType="numeric"
+          onChangeText={handleSearchDebounceChange}
+        />
+        <Paragraph style={styles.paragraphSmall}>
+          Time in milliseconds to wait after typing before triggering a search.
+          {searchDebounceTime !== undefined && searchDebounceTime !== appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME && (
+            <>
+              {' '}
+              <Text style={styles.link} onPress={askResetSearchDebounce}>
+                Reset to default.
+              </Text>
+            </>
           )}
         </Paragraph>
       </ToggleCard>

--- a/src/screens/Settings/styles.ts
+++ b/src/screens/Settings/styles.ts
@@ -14,12 +14,12 @@ const styles = StyleSheet.create({
     marginBottom: Theme.spacing.large
   },
   paragraphSmall: {
-    marginBottom: Theme.spacing.small,
+    marginBottom: Theme.spacing.large,
     fontSize: 12,
     color: Theme.colors.backdrop
   },
   input: {
-    marginBottom: Theme.spacing.large
+    marginBottom: 2
   },
   link: {
     color: Theme.colors.primary,

--- a/src/screens/Sortation/ContainerMismatchDialog.tsx
+++ b/src/screens/Sortation/ContainerMismatchDialog.tsx
@@ -5,7 +5,7 @@ import { Text } from 'react-native-paper';
 import Button from '../../components/Button';
 import { ContainerIcon } from '../../components/Icons';
 import { ScannerInput } from '../../components/ScannerInput';
-import { EMPTY_STRING, HYPHEN } from '../../constants';
+import { appConfig, EMPTY_STRING, HYPHEN } from '../../constants';
 import Theme from '../../utils/Theme';
 import styles from './styles';
 
@@ -72,7 +72,7 @@ export function ContainerMismatchDialog({
               label="Container"
               placeholder="Scan or type the container"
               value={dialogInput}
-              autoSubmitTimeout={0}
+              autoSubmitTimeout={appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME}
               onChange={setDialogInput}
               onSubmit={handleScanSubmit}
             />

--- a/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
+++ b/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux';
 
 import Button from '../../components/Button';
 import { ScannerInput } from '../../components/ScannerInput';
-import { EMPTY_STRING } from '../../constants';
+import { appConfig, EMPTY_STRING } from '../../constants';
 import { getAlternativeDestinationsAction, searchLocationByLocationNumber } from '../../redux/actions/locations';
 import { SortationLocation, SortationTask } from '../../types/sortation';
 import styles from './styles';
@@ -130,6 +130,7 @@ export default function AlternativeLocationSelector({
 
           <ScannerInput
             label="Scan location number"
+            autoSubmitTimeout={appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME}
             value={scannedLocationInput}
             onChange={setScannedLocationInput}
             onSubmit={handleLocationSearch}


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-278

Changes:
- Add searchDebounceTime to settings reducer and Settings screen
- Rename "Scanner Settings" to "Debounce Settings" with separate resets
- Apply debounce to BarcodeSearchHeader (with prop override), AsyncModalSelect, and SearchButton
- Use search debounce default in Sortation dialogs for scanner input timeout

<img width="350" height="315" alt="image" src="https://github.com/user-attachments/assets/98fbb2aa-b052-43f9-b096-9bd1f328084a" />
