### PR TITLE
OBLS-504 Fix crash after 0-qty short pick when requisition is auto-ca…

### DIFF
--- a/src/redux/actions/picking.ts
+++ b/src/redux/actions/picking.ts
@@ -44,7 +44,7 @@ export const REALLOCATE_PICK_TASK_REQUEST_FAIL = 'REALLOCATE_PICK_TASK_REQUEST_F
 export function getPickTasksAction(
   params: PickTaskParams,
   callback: (response: {
-    response: {
+    response?: {
       data: PickTask[];
       errorCode?: string;
       message?: string;
@@ -52,6 +52,7 @@ export function getPickTasksAction(
       offset?: number;
       totalCount?: number;
     };
+    errorMessage?: string;
   }) => void
 ) {
   return {
@@ -131,11 +132,12 @@ export function dropPickTaskAction(
 export function getPickTaskByIdAction(
   taskId: string,
   callback: (response: {
-    response: {
+    response?: {
       data: PickTask;
       errorCode?: string;
       message?: string;
     };
+    errorMessage?: string;
   }) => void
 ) {
   return {

--- a/src/redux/sagas/picking.ts
+++ b/src/redux/sagas/picking.ts
@@ -51,8 +51,9 @@ function* getPickTasksAction(action: any) {
     yield put({ type: GET_PICK_TASKS_REQUEST_SUCCESS, payload: response.data });
     yield put(hideScreenLoading());
   } catch (error) {
-    yield put({ type: GET_PICK_TASKS_REQUEST_FAIL, payload: (error as any)?.message || 'Error Fetching Tasks' });
-    yield action.callback({ error });
+    const errorMessage = (error as any)?.message || 'Error Fetching Tasks';
+    yield put({ type: GET_PICK_TASKS_REQUEST_FAIL, payload: errorMessage });
+    yield action.callback({ errorMessage });
     yield put(hideScreenLoading());
   }
 }
@@ -208,11 +209,12 @@ function* getPickTaskByIdAction(action: any) {
     yield put(hideScreenLoading());
     yield action.callback({ response });
   } catch (error) {
+    const errorMessage = (error as any)?.message || 'Error Fetching Pick Task';
     yield put({
       type: GET_PICK_TASK_BY_ID_REQUEST_FAIL,
-      payload: (error as any)?.message || 'Error Fetching Pick Task'
+      payload: errorMessage
     });
-    yield action.callback({ error });
+    yield action.callback({ errorMessage });
     yield put(hideScreenLoading());
   }
 }

--- a/src/screens/Picking/PickingContext.tsx
+++ b/src/screens/Picking/PickingContext.tsx
@@ -47,7 +47,7 @@ type PickingContextType = {
   /** Drop the current pick task at the staging location */
   dropCurrentTask: (task: PickTask, callback?: (response: { errorMessage?: string }) => void) => void;
   /** Revalidates the current pick task details from the server */
-  revalidateCurrentTask: (callback?: (task: PickTask) => void) => void;
+  revalidateCurrentTask: (callback?: (task: PickTask | undefined) => void) => void;
   /** Advances to the next task in the list */
   goToNextTask: () => void;
 };
@@ -64,7 +64,13 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
   const startSession = async (deliveryType: DeliveryType, ordersCount: number): Promise<boolean> => {
     return new Promise((resolve) => {
       dispatch(
-        getPickTasksAction({ deliveryTypeCode: deliveryType.code, ordersCount }, ({ response }) => {
+        getPickTasksAction({ deliveryTypeCode: deliveryType.code, ordersCount }, ({ response, errorMessage }) => {
+          if (errorMessage || !response) {
+            Alert.alert('Error', errorMessage ?? 'Failed to load pick tasks.');
+            resolve(false);
+            return;
+          }
+
           if (response.errorCode) {
             Alert.alert('Error', response.message ?? 'Failed to load pick tasks.');
             navigate('PickingPickType');
@@ -116,15 +122,16 @@ export function PickingProvider({ children }: { children: React.ReactNode }) {
     dispatch(shortPickTaskAction(currentTask.id, outboundContainerId, parsedQuantityPicked, callback, reasonCodeName));
   };
 
-  const revalidateCurrentTask = (callback?: (task: PickTask) => void) => {
+  const revalidateCurrentTask = (callback?: (task: PickTask | undefined) => void) => {
     if (!currentTask) {
       return;
     }
 
     dispatch(
-      getPickTaskByIdAction(currentTask.id, ({ response }) => {
-        if (response.errorCode || !response.data) {
-          Alert.alert('Error', 'Failed to revalidate the current pick task.');
+      getPickTaskByIdAction(currentTask.id, ({ response, errorMessage }) => {
+        if (errorMessage || !response?.data) {
+          Alert.alert('Error', errorMessage ?? 'Failed to revalidate the current pick task.');
+          callback?.(undefined);
           return;
         }
 

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -13,13 +13,12 @@ import { navigate } from '../../NavigationService';
 import { getReasonCodesAction } from '../../redux/actions/others';
 import { ReasonCode } from '../../types/picking';
 import { parseFromISODateToLocaleString } from '../../utils/utils';
-import { revalidateTaskAndProceed } from './lib';
+import { proceedToNextOrComplete } from './lib';
 import { usePickingContext } from './PickingContext';
 import styles from './styles';
 
 export default function PickingPickQuantityScreen() {
-  const { currentTask, currentTaskIndex, allTasksCount, shortPickTask, revalidateCurrentTask, goToNextTask } =
-    usePickingContext();
+  const { currentTask, currentTaskIndex, allTasksCount, shortPickTask, goToNextTask } = usePickingContext();
   const dispatch = useDispatch();
   const isFocused = useIsFocused();
 
@@ -99,7 +98,8 @@ export default function PickingPickQuantityScreen() {
             return;
           }
 
-          revalidateTaskAndProceed(revalidateCurrentTask, currentTaskIndex, allTasksCount, goToNextTask);
+          // Skip revalidation: task is closed server-side, and GET /pick-tasks/:id 404s if the requisition is canceled.
+          proceedToNextOrComplete(currentTaskIndex, allTasksCount, goToNextTask);
         },
         reasonCode?.name
       );

--- a/src/screens/Picking/lib.ts
+++ b/src/screens/Picking/lib.ts
@@ -2,8 +2,28 @@ import { Alert } from 'react-native';
 import { navigate, resetToRoutes } from '../../NavigationService';
 import { PickTask } from '../../types/picking';
 
+export function proceedToNextOrComplete(currentTaskIndex: number, allTasksCount: number, goToNextTask: () => void) {
+  if (currentTaskIndex + 1 < allTasksCount) {
+    goToNextTask();
+    navigate('PickingPickLocation');
+    return;
+  }
+
+  Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
+    {
+      text: 'OK',
+      onPress: () =>
+        resetToRoutes([
+          { name: 'Drawer', params: { screen: 'Dashboard' } },
+          { name: 'PickingPickType' },
+          { name: 'PickingPickStagingLocation' }
+        ])
+    }
+  ]);
+}
+
 export function revalidateTaskAndProceed(
-  revalidateCurrentTask: (callback: (revalidatedTask: PickTask) => void) => void,
+  revalidateCurrentTask: (callback: (revalidatedTask: PickTask | undefined) => void) => void,
   currentTaskIndex: number,
   allTasksCount: number,
   goToNextTask: () => void,
@@ -15,14 +35,9 @@ export function revalidateTaskAndProceed(
       return;
     }
 
-    // If it's not the last task, go to the next one
-    if (!(currentTaskIndex + 1 >= allTasksCount)) {
-      goToNextTask();
-      navigate('PickingPickLocation');
-      return;
-    }
+    const isLastTask = currentTaskIndex + 1 >= allTasksCount;
 
-    if (omitStagingLocationStep) {
+    if (isLastTask && omitStagingLocationStep) {
       Alert.alert(
         'Short Pick Without Reason Code',
         'You have completed all picks with a short pick without a reason code. This task will remain available to pick. You will be redirected to the Pick Type screen.',
@@ -36,12 +51,6 @@ export function revalidateTaskAndProceed(
       return;
     }
 
-    Alert.alert('All Picks Complete', 'You have completed all picks. Proceeding to staging location drop.', [
-      {
-        text: 'OK',
-        onPress: () =>
-          resetToRoutes([{ name: 'Drawer', params: { screen: 'Dashboard' } }, { name: 'PickingPickType' }, { name: 'PickingPickStagingLocation' }])
-      }
-    ]);
+    proceedToNextOrComplete(currentTaskIndex, allTasksCount, goToNextTask);
   });
 }


### PR DESCRIPTION
…nceled

https://openboxes.atlassian.net/browse/OBLS-504

Needs: https://github.com/openboxes/openboxes/commit/aa1bf6a5a671c9d41ff5b79c2108e09aa2438a03

Changes:
  - Skip revalidation on the 0-qty short pick path; navigate directly to
    the next task or the completion flow.
  - Make startSession and revalidateCurrentTask defensive against the
    saga's error shape; align all picking sagas on { errorMessage } for
    the error callback contract.
  - Widen callback types on getPickTasksAction and getPickTaskByIdAction
    accordingly.
  - Extract proceedToNextOrComplete helper shared between the 0-qty path
    and revalidateTaskAndProceed.