### PR TITLE
OBLS-736 Add create transfer feature

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -84,6 +84,11 @@ import { ReplenishmentStagingLocationScreen } from './screens/Replenishment/Repl
 import Transfer from './screens/Transfer';
 import Transfers from './screens/Transfers';
 import TransferDetails from './screens/TransfersDetails';
+import CreateTransferEntryScreen from './screens/CreateTransfer/CreateTransferEntryScreen';
+import CreateTransferItemListScreen from './screens/CreateTransfer/CreateTransferItemListScreen';
+import CreateTransferQuantityScreen from './screens/CreateTransfer/CreateTransferQuantityScreen';
+import CreateTransferDestinationScreen from './screens/CreateTransfer/CreateTransferDestinationScreen';
+import CreateTransferCompleteScreen from './screens/CreateTransfer/CreateTransferCompleteScreen';
 import ViewAvailableItem from './screens/ViewAvailableItem';
 import ApiClient from './utils/ApiClient';
 import Theme from './utils/Theme';
@@ -270,6 +275,31 @@ class Main extends Component<Props, State> {
               />
               <Stack.Screen name="AdjustStock" component={AdjustStock} options={{ title: 'Adjust Stock' }} />
               <Stack.Screen name="Transfer" component={Transfer} options={{ title: 'Transfer' }} />
+              <Stack.Screen
+                name="CreateTransferEntry"
+                component={CreateTransferEntryScreen}
+                options={{ title: 'Create Transfer' }}
+              />
+              <Stack.Screen
+                name="CreateTransferItemList"
+                component={CreateTransferItemListScreen}
+                options={{ title: 'Transfer Items' }}
+              />
+              <Stack.Screen
+                name="CreateTransferQuantity"
+                component={CreateTransferQuantityScreen}
+                options={{ title: 'Transfer Quantity' }}
+              />
+              <Stack.Screen
+                name="CreateTransferDestination"
+                component={CreateTransferDestinationScreen}
+                options={{ title: 'Transfer Destination' }}
+              />
+              <Stack.Screen
+                name="CreateTransferComplete"
+                component={CreateTransferCompleteScreen}
+                options={{ title: 'Complete Transfer' }}
+              />
               <Stack.Screen
                 name="ShipmentDetails"
                 component={ShipItemDetails}

--- a/src/apis/createTransfer.ts
+++ b/src/apis/createTransfer.ts
@@ -1,0 +1,35 @@
+import { StockTransferPayload } from '../screens/CreateTransfer/types';
+import apiClient from '../utils/ApiClient';
+
+export function getStockTransferCandidates(facilityId: string) {
+  return apiClient.get(`/stockTransfers/candidates?location.id=${encodeURIComponent(facilityId)}`);
+}
+
+export function lookupBarcodeProduct(code: string) {
+  return apiClient.get(`/barcodes/${encodeURIComponent(code)}`);
+}
+
+export function lookupLocationByCode(code: string) {
+  return apiClient.get(`/locations/${encodeURIComponent(code)}`);
+}
+
+export function searchDestinationBins(searchTerm: string) {
+  const term = encodeURIComponent(searchTerm || '');
+  return apiClient.get(
+    `/internalLocations/search?searchTerm=${term}` +
+      '&locationTypeCode=BIN_LOCATION&locationTypeCode=INTERNAL' +
+      '&ignoreActivityCodes=RECEIVE_STOCK'
+  );
+}
+
+export function postStockTransfer(payload: StockTransferPayload) {
+  return apiClient.post('/stockTransfers', payload);
+}
+
+export function getStockTransferById(id: string) {
+  return apiClient.get(`/stockTransfers/${encodeURIComponent(id)}`);
+}
+
+export function putStockTransfer(id: string, body: any) {
+  return apiClient.put(`/stockTransfers/${encodeURIComponent(id)}`, body);
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -11,3 +11,4 @@ export * from './transfers';
 export * from './others';
 export * from './picking';
 export * from './pua';
+export * from './createTransfer';

--- a/src/components/SearchButton/searchProviders.ts
+++ b/src/components/SearchButton/searchProviders.ts
@@ -1,5 +1,6 @@
 import Location from '../../data/location/Location';
 import Product from '../../data/product/Product';
+import { searchDestinationBinsAction, searchProductOrLocationAction } from '../../redux/actions/createTransfer';
 import { searchInternalLocations } from '../../redux/actions/locations';
 import { searchProductGloballyAction } from '../../redux/actions/products';
 
@@ -47,25 +48,71 @@ function createProductAction(term: string, callback: SearchCallback) {
   );
 }
 
+function locationToSearchResult(item: Location): SearchResult {
+  return {
+    id: item.id,
+    label: item.locationNumber || item.name,
+    subtitle: item.name,
+    value: item.locationNumber
+  };
+}
+
+function handleLocationSearchResponse(
+  response: SearchResponse<Location>,
+  callback: SearchCallback,
+  failureMessage: string
+) {
+  if (response?.error) {
+    callback({ error: response.errorMessage || failureMessage });
+    return;
+  }
+  callback({ results: (response?.data || []).map(locationToSearchResult) });
+}
+
 function createLocationAction(term: string, callback: SearchCallback) {
   return searchInternalLocations(
     term,
     null,
-    (response: SearchResponse<Location>) => {
+    (response: SearchResponse<Location>) =>
+      handleLocationSearchResponse(response, callback, 'Failed to search locations.'),
+    true
+  );
+}
+
+function createProductOrLocationAction(term: string, callback: SearchCallback) {
+  return searchProductOrLocationAction(
+    term,
+    (response: { products?: Product[]; locations?: Location[]; error?: boolean; errorMessage?: string }) => {
       if (response?.error) {
-        callback({ error: response.errorMessage || 'Failed to search locations.' });
+        callback({ error: response.errorMessage || 'Failed to search.' });
         return;
       }
 
-      callback({
-        results: (response?.data || []).map((item) => ({
-          id: item.id,
-          label: item.locationNumber || item.name,
-          subtitle: item.name,
-          value: item.locationNumber
-        }))
-      });
+      const productResults: SearchResult[] = (response?.products || []).map((item) => ({
+        id: `product:${item.id}`,
+        label: item.productCode || item.name,
+        subtitle: `Product · ${item.name}`,
+        value: item.productCode
+      }));
+
+      const locationResults: SearchResult[] = (response?.locations || []).map((item) => ({
+        id: `location:${item.id}`,
+        label: item.locationNumber || item.name,
+        subtitle: `Bin · ${item.name}`,
+        value: item.locationNumber
+      }));
+
+      callback({ results: [...productResults, ...locationResults] });
     },
+    true
+  );
+}
+
+function createDestinationBinAction(term: string, callback: SearchCallback) {
+  return searchDestinationBinsAction(
+    term,
+    (response: SearchResponse<Location>) =>
+      handleLocationSearchResponse(response, callback, 'Failed to search destination bins.'),
     true
   );
 }
@@ -88,6 +135,18 @@ export const searchProviders = {
     placeholder: 'Search by name or number...',
     inputLabel: 'Container ID',
     createAction: createLocationAction
+  },
+  destinationBin: {
+    title: 'Search Destination Bin',
+    placeholder: 'Search by name or number...',
+    inputLabel: 'Destination Bin',
+    createAction: createDestinationBinAction
+  },
+  productOrLocation: {
+    title: 'Search Product or Bin',
+    placeholder: 'Product or bin code...',
+    inputLabel: 'Product or Bin',
+    createAction: createProductOrLocationAction
   }
 };
 

--- a/src/redux/actions/createTransfer.ts
+++ b/src/redux/actions/createTransfer.ts
@@ -1,0 +1,68 @@
+export const GET_STOCK_TRANSFER_CANDIDATES = 'CREATE_TRANSFER/GET_CANDIDATES';
+export const LOOKUP_TRANSFER_BARCODE = 'CREATE_TRANSFER/LOOKUP_BARCODE';
+export const LOOKUP_LOCATION_BY_CODE = 'CREATE_TRANSFER/LOOKUP_LOCATION';
+export const SEARCH_PRODUCT_OR_LOCATION = 'CREATE_TRANSFER/SEARCH_PRODUCT_OR_LOCATION';
+export const SEARCH_DESTINATION_BINS = 'CREATE_TRANSFER/SEARCH_DESTINATION_BINS';
+export const SUBMIT_CREATE_TRANSFER = 'CREATE_TRANSFER/SUBMIT';
+export const COMPLETE_CREATE_TRANSFER = 'CREATE_TRANSFER/COMPLETE';
+
+type Callback<T = any> = (data: T) => void;
+
+export function getStockTransferCandidatesAction(facilityId: string, callback: Callback, suppressLoading?: boolean) {
+  return {
+    type: GET_STOCK_TRANSFER_CANDIDATES,
+    payload: { facilityId },
+    callback,
+    suppressLoading
+  };
+}
+
+export function lookupTransferBarcodeAction(code: string, callback: Callback) {
+  return {
+    type: LOOKUP_TRANSFER_BARCODE,
+    payload: { code },
+    callback
+  };
+}
+
+export function lookupLocationByCodeAction(code: string, callback: Callback) {
+  return {
+    type: LOOKUP_LOCATION_BY_CODE,
+    payload: { code },
+    callback
+  };
+}
+
+export function searchProductOrLocationAction(searchTerm: string, callback: Callback, suppressLoading?: boolean) {
+  return {
+    type: SEARCH_PRODUCT_OR_LOCATION,
+    payload: { searchTerm },
+    callback,
+    suppressLoading
+  };
+}
+
+export function searchDestinationBinsAction(searchTerm: string, callback: Callback, suppressLoading?: boolean) {
+  return {
+    type: SEARCH_DESTINATION_BINS,
+    payload: { searchTerm },
+    callback,
+    suppressLoading
+  };
+}
+
+export function submitCreateTransferAction(payload: any, callback: Callback) {
+  return {
+    type: SUBMIT_CREATE_TRANSFER,
+    payload,
+    callback
+  };
+}
+
+export function completeCreateTransferAction(transferId: string, callback: Callback) {
+  return {
+    type: COMPLETE_CREATE_TRANSFER,
+    payload: { transferId },
+    callback
+  };
+}

--- a/src/redux/sagas/createTransfer.ts
+++ b/src/redux/sagas/createTransfer.ts
@@ -1,0 +1,135 @@
+import { all, call, takeLatest } from 'redux-saga/effects';
+
+import * as api from '../../apis';
+import { parseResponse } from '../../utils/utils';
+import {
+  COMPLETE_CREATE_TRANSFER,
+  GET_STOCK_TRANSFER_CANDIDATES,
+  LOOKUP_LOCATION_BY_CODE,
+  LOOKUP_TRANSFER_BARCODE,
+  SEARCH_DESTINATION_BINS,
+  SEARCH_PRODUCT_OR_LOCATION,
+  SUBMIT_CREATE_TRANSFER
+} from '../actions/createTransfer';
+import { STOCK_TRANSFER_STATUS } from '../../screens/CreateTransfer/utils';
+import Product from '../../data/product/Product';
+import Location from '../../data/location/Location';
+
+function* getCandidates(action: any) {
+  try {
+    const response = yield call(api.getStockTransferCandidates, action.payload.facilityId);
+    // /candidates returns flat dot-notation keys; expand to nested before use.
+    yield action.callback({ data: parseResponse(response?.data) });
+  } catch (e: any) {
+    yield action.callback({ error: true, errorMessage: e?.message });
+  }
+}
+
+function* lookupBarcode(action: any) {
+  // BE wraps "not found" as various non-404 statuses; swallow per-leg.
+  let product: Product | null = null;
+  try {
+    const productResp = yield call(api.lookupBarcodeProduct, action.payload.code);
+    product = productResp?.data;
+  } catch (_e) {
+    // No-op; we'll try location next.
+  }
+  if (product) {
+    yield action.callback({ kind: 'product', product });
+    return;
+  }
+
+  let location: Location | null = null;
+  try {
+    const locResp = yield call(api.lookupLocationByCode, action.payload.code);
+    location = locResp?.data;
+  } catch (_e) {
+    // No-op; we'll return "not found" next.
+  }
+  if (location) {
+    yield action.callback({ kind: 'location', location });
+    return;
+  }
+
+  yield action.callback({ kind: 'none' });
+}
+
+function* lookupLocation(action: any) {
+  try {
+    const resp = yield call(api.lookupLocationByCode, action.payload.code);
+    yield action.callback(resp);
+  } catch (e: any) {
+    yield action.callback({ error: true, errorMessage: e?.message });
+  }
+}
+
+function* safeCall(fn: any, ...args: any[]): any {
+  try {
+    return yield call(fn, ...args);
+  } catch (_e) {
+    return null;
+  }
+}
+
+function* searchProductOrLocation(action: any) {
+  const term = action.payload.searchTerm;
+  // Parallel, per-leg fault-tolerant: a flaky leg shouldn't blank out the other.
+  const [productResp, locResp] = yield all([
+    call(safeCall, api.searchProductGlobally, term),
+    call(safeCall, api.searchInternalLocations, term, null)
+  ]);
+  if (!productResp && !locResp) {
+    yield action.callback({ error: true, errorMessage: 'Search failed.' });
+    return;
+  }
+  yield action.callback({
+    products: productResp?.data ?? [],
+    locations: locResp?.data ?? []
+  });
+}
+
+function* searchDestBins(action: any) {
+  try {
+    const response = yield call(api.searchDestinationBins, action.payload.searchTerm);
+    yield action.callback(response);
+  } catch (e: any) {
+    yield action.callback({ error: true, errorMessage: e?.message });
+  }
+}
+
+function* submitCreateTransfer(action: any) {
+  try {
+    const response = yield call(api.postStockTransfer, action.payload);
+    yield action.callback(response);
+  } catch (e: any) {
+    yield action.callback({ error: true, errorMessage: e?.message });
+  }
+}
+
+function* completeCreateTransfer(action: any) {
+  const { transferId } = action.payload;
+  try {
+    const getResp = yield call(api.getStockTransferById, transferId);
+    // BE iterates items expecting nested keys; expand the flat-key GET body.
+    const transferBody = parseResponse(getResp?.data);
+    if (!transferBody) {
+      yield action.callback({ error: true, errorMessage: 'Transfer not found.' });
+      return;
+    }
+    const completedBody = { ...transferBody, status: STOCK_TRANSFER_STATUS.COMPLETED };
+    const putResp = yield call(api.putStockTransfer, transferId, completedBody);
+    yield action.callback(putResp);
+  } catch (e: any) {
+    yield action.callback({ error: true, errorMessage: e?.message });
+  }
+}
+
+export default function* watcher() {
+  yield takeLatest(GET_STOCK_TRANSFER_CANDIDATES, getCandidates);
+  yield takeLatest(LOOKUP_TRANSFER_BARCODE, lookupBarcode);
+  yield takeLatest(LOOKUP_LOCATION_BY_CODE, lookupLocation);
+  yield takeLatest(SEARCH_PRODUCT_OR_LOCATION, searchProductOrLocation);
+  yield takeLatest(SEARCH_DESTINATION_BINS, searchDestBins);
+  yield takeLatest(SUBMIT_CREATE_TRANSFER, submitCreateTransfer);
+  yield takeLatest(COMPLETE_CREATE_TRANSFER, completeCreateTransfer);
+}

--- a/src/redux/sagas/index.ts
+++ b/src/redux/sagas/index.ts
@@ -11,6 +11,7 @@ import transfers from './transfers';
 import packing from './packing';
 import others from './others';
 import picking from './picking';
+import createTransfer from './createTransfer';
 
 export default function* root() {
   const sagas = [
@@ -25,7 +26,8 @@ export default function* root() {
     packing,
     lpn,
     others,
-    picking
+    picking,
+    createTransfer
   ];
   yield all(sagas.map(fork));
 }

--- a/src/screens/CreateTransfer/CreateTransferCompleteScreen.tsx
+++ b/src/screens/CreateTransfer/CreateTransferCompleteScreen.tsx
@@ -1,0 +1,120 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
+import React, { useMemo, useState } from 'react';
+import { Alert, ScrollView, View } from 'react-native';
+import { Caption, Divider, Text } from 'react-native-paper';
+import { useDispatch } from 'react-redux';
+
+import Button from '../../components/Button';
+import { QuantityIcon } from '../../components/Icons';
+import { resetToRoutes } from '../../NavigationService';
+import { completeCreateTransferAction } from '../../redux/actions/createTransfer';
+import { DetailChip } from '../../types/sortation';
+import CreateTransferDetailsPanel from './CreateTransferDetailsPanel';
+import styles from './styles';
+import { CreateTransferStackParams } from './types';
+import { formatLotExpiry } from './utils';
+
+type CompleteRouteProp = RouteProp<CreateTransferStackParams, 'CreateTransferComplete'>;
+
+type CompletionState = 'idle' | 'completing' | 'completed';
+
+const renderQuantityIcon = () => <QuantityIcon size={16} color="#000" />;
+
+export default function CreateTransferCompleteScreen() {
+  const { params } = useRoute<CompleteRouteProp>();
+  const { transferId, stockTransferNumber, item, quantity, destination } = params;
+  const dispatch = useDispatch();
+
+  const [completionState, setCompletionState] = useState<CompletionState>('idle');
+
+  function handleComplete() {
+    setCompletionState('completing');
+    dispatch(
+      completeCreateTransferAction(transferId, (response: any) => {
+        if (response && !response.error) {
+          setCompletionState('completed');
+        } else {
+          setCompletionState('idle');
+          Alert.alert('Complete Transfer Failed', response?.errorMessage || 'Failed to complete transfer.');
+        }
+      })
+    );
+  }
+
+  function handleNewTransfer() {
+    resetToRoutes([{ name: 'Drawer', params: { screen: 'Dashboard' } }, { name: 'CreateTransferEntry' }]);
+  }
+
+  const detailsChips = useMemo<DetailChip[]>(
+    () => [
+      {
+        icon: 'airplane-takeoff',
+        label: 'From',
+        value: item.originBinLocation.locationNumber || item.originBinLocation.name
+      },
+      {
+        icon: 'airplane-landing',
+        label: 'To',
+        value: destination.locationNumber || destination.name,
+        isActive: true
+      },
+      {
+        icon: 'tag',
+        label: 'Lot',
+        value: formatLotExpiry(item.lotNumber, item.expirationDate)
+      },
+      {
+        icon: renderQuantityIcon,
+        label: 'Quantity',
+        value: quantity
+      }
+    ],
+    [
+      item.originBinLocation.locationNumber,
+      item.originBinLocation.name,
+      destination.locationNumber,
+      destination.name,
+      item.lotNumber,
+      item.expirationDate,
+      quantity
+    ]
+  );
+
+  const isCompleting = completionState === 'completing';
+  const isCompleted = completionState === 'completed';
+
+  return (
+    <View style={styles.screenRoot}>
+      <ScrollView keyboardShouldPersistTaps="always" style={styles.scrollContent}>
+        <CreateTransferDetailsPanel
+          productCode={item.product.productCode}
+          productName={item.product.name}
+          detailsChips={detailsChips}
+        />
+
+        <Divider />
+      </ScrollView>
+
+      <View style={styles.footerContainer}>
+        {isCompleted && (
+          <View style={styles.refBand}>
+            <Caption style={styles.refLabel}>Reference Number</Caption>
+            <Text style={styles.refValue}>{stockTransferNumber}</Text>
+          </View>
+        )}
+
+        {isCompleted ? (
+          <Button title="New Transfer" mode="contained" size="100%" onPress={handleNewTransfer} />
+        ) : (
+          <Button
+            title={isCompleting ? 'Completing...' : 'Complete Transfer'}
+            mode="contained"
+            size="100%"
+            disabled={isCompleting}
+            onPress={handleComplete}
+          />
+        )}
+      </View>
+    </View>
+  );
+}

--- a/src/screens/CreateTransfer/CreateTransferDestinationScreen.tsx
+++ b/src/screens/CreateTransfer/CreateTransferDestinationScreen.tsx
@@ -1,0 +1,196 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Alert, ScrollView, View } from 'react-native';
+import { Divider, Text } from 'react-native-paper';
+import { useDispatch } from 'react-redux';
+
+import Button from '../../components/Button';
+import { LocationIcon, QuantityIcon } from '../../components/Icons';
+import { ScannerInput } from '../../components/ScannerInput';
+import { SearchButton } from '../../components/SearchButton';
+import { useSearchButton } from '../../components/SearchButton/useSearchButton';
+import { EMPTY_STRING } from '../../constants';
+import { replace } from '../../NavigationService';
+import { lookupLocationByCodeAction, submitCreateTransferAction } from '../../redux/actions/createTransfer';
+import { DetailChip } from '../../types/sortation';
+import CreateTransferDetailsPanel from './CreateTransferDetailsPanel';
+import styles from './styles';
+import { CreateTransferStackParams, DestinationBin, StockTransferPayload } from './types';
+import { formatLotExpiry, STOCK_TRANSFER_STATUS } from './utils';
+
+type DestinationRouteProp = RouteProp<CreateTransferStackParams, 'CreateTransferDestination'>;
+
+const renderQuantityIcon = () => <QuantityIcon size={16} color="#000" />;
+
+export default function CreateTransferDestinationScreen() {
+  const { params } = useRoute<DestinationRouteProp>();
+  const { item, quantity } = params;
+  const dispatch = useDispatch();
+
+  const [destinationCode, setDestinationCode] = useState<string>(EMPTY_STRING);
+  const [destination, setDestination] = useState<DestinationBin | null>(null);
+  const [destinationError, setDestinationError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleDestinationChange = useCallback((next: string) => {
+    setDestinationCode(next);
+    // Editing invalidates any previously resolved destination.
+    setDestination(null);
+    setDestinationError(null);
+  }, []);
+
+  const resolveDestination = useCallback(
+    (code: string) => {
+      if (!code || code.trim() === '') {
+        setDestination(null);
+        setDestinationError(null);
+        return;
+      }
+      setDestinationError(null);
+      dispatch(
+        lookupLocationByCodeAction(code.trim(), (resp: any) => {
+          if (resp && !resp.error && resp.data) {
+            const loc = resp.data;
+            if (loc.id === item.originBinLocation.id) {
+              setDestination(null);
+              setDestinationError('Destination cannot be the same as source bin.');
+              return;
+            }
+            setDestination({
+              id: loc.id,
+              name: loc.name,
+              locationNumber: loc.locationNumber
+            });
+            setDestinationError(null);
+          } else {
+            setDestination(null);
+            setDestinationError('Bin not found.');
+          }
+        })
+      );
+    },
+    [dispatch, item.originBinLocation.id]
+  );
+
+  const handleModalSelect = useCallback(
+    (code: string) => {
+      setDestinationCode(code);
+      resolveDestination(code);
+    },
+    [resolveDestination]
+  );
+
+  const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: handleModalSelect });
+
+  function handleSubmit() {
+    if (!destination) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const payload: StockTransferPayload = {
+      stockTransferItems: [
+        {
+          id: null,
+          productAvailabilityId: item.productAvailabilityId,
+          product: { id: item.product.id },
+          inventoryItem: { id: item.inventoryItemId },
+          originBinLocation: { id: item.originBinLocation.id },
+          destinationBinLocation: { id: destination.id },
+          quantity,
+          quantityOnHand: item.quantityOnHand,
+          quantityNotPicked: item.quantityNotPicked,
+          status: STOCK_TRANSFER_STATUS.PENDING,
+          splitItems: [],
+          sortOrder: 0
+        }
+      ]
+    };
+
+    dispatch(
+      submitCreateTransferAction(payload, (response: any) => {
+        setIsSubmitting(false);
+        if (response && !response.error && response.data) {
+          const created = response.data;
+          replace('CreateTransferComplete', {
+            transferId: created.id,
+            stockTransferNumber: created.stockTransferNumber || created.id,
+            item,
+            quantity,
+            destination
+          });
+        } else {
+          Alert.alert('Transfer Failed', response?.errorMessage || 'An error occurred while creating the transfer.');
+        }
+      })
+    );
+  }
+
+  const detailsChips = useMemo<DetailChip[]>(
+    () => [
+      {
+        icon: 'airplane-takeoff',
+        label: 'From',
+        value: item.originBinLocation.locationNumber || item.originBinLocation.name,
+        isActive: true
+      },
+      {
+        icon: 'tag',
+        label: 'Lot',
+        value: formatLotExpiry(item.lotNumber, item.expirationDate)
+      },
+      {
+        icon: renderQuantityIcon,
+        label: 'Quantity',
+        value: quantity
+      }
+    ],
+    [item.originBinLocation.locationNumber, item.originBinLocation.name, item.lotNumber, item.expirationDate, quantity]
+  );
+
+  const transferEnabled = !isSubmitting && !!destination;
+
+  return (
+    <View style={styles.screenRoot}>
+      <ScrollView keyboardShouldPersistTaps="always" style={styles.scrollContent}>
+        <CreateTransferDetailsPanel
+          productCode={item.product.productCode}
+          productName={item.product.name}
+          detailsChips={detailsChips}
+        />
+
+        <Divider />
+
+        <View style={styles.formContainer}>
+          <View style={styles.scannerRow}>
+            <ScannerInput
+              style={styles.scannerInput}
+              label="Destination"
+              placeholder="Scan or select destination bin"
+              leftIcon={<LocationIcon size={24} />}
+              value={destinationCode}
+              isEnabled={!isSearchOpen}
+              danger={!!destinationError}
+              onChange={handleDestinationChange}
+              onSubmit={resolveDestination}
+            />
+            <SearchButton searchType="destinationBin" {...searchButtonProps} />
+          </View>
+
+          {destinationError ? <Text style={styles.errorText}>{destinationError}</Text> : null}
+        </View>
+      </ScrollView>
+
+      <View style={styles.footerContainer}>
+        <Button
+          title={isSubmitting ? 'Submitting...' : 'Transfer'}
+          mode="contained"
+          size="100%"
+          disabled={!transferEnabled}
+          onPress={handleSubmit}
+        />
+      </View>
+    </View>
+  );
+}

--- a/src/screens/CreateTransfer/CreateTransferDetailsPanel.tsx
+++ b/src/screens/CreateTransfer/CreateTransferDetailsPanel.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Chip, Divider, Text, Title } from 'react-native-paper';
+
+import { ProductIcon } from '../../components/Icons';
+import { EMPTY_FALLBACK } from '../../constants';
+import { DetailChip } from '../../types/sortation';
+import styles from './styles';
+
+export type CreateTransferDetailsPanelProps = {
+  productCode: string;
+  productName: string;
+  detailsChips: DetailChip[];
+};
+
+const renderProductIcon = () => <ProductIcon size={16} color="#000" />;
+
+function CreateTransferDetailsPanel({ productCode, productName, detailsChips }: CreateTransferDetailsPanelProps) {
+  return (
+    <View style={styles.productDetails}>
+      <View style={styles.headerRow}>
+        <Chip icon={renderProductIcon} style={styles.chipDefault} textStyle={styles.chipText}>
+          {productCode}
+        </Chip>
+      </View>
+
+      <Divider style={styles.contentDivider} />
+
+      <Title style={styles.title}>{productName}</Title>
+
+      {detailsChips.map(({ icon, value, label, isActive }) => (
+        <Chip key={label} icon={icon} style={[styles.chipDefault, styles.topSpace, isActive && styles.chipActive]}>
+          <Text style={styles.chipText}>
+            {label}: <Text style={[styles.bold, styles.chipText]}>{value ?? EMPTY_FALLBACK}</Text>
+          </Text>
+        </Chip>
+      ))}
+    </View>
+  );
+}
+
+export default React.memo(CreateTransferDetailsPanel);

--- a/src/screens/CreateTransfer/CreateTransferEntryScreen.tsx
+++ b/src/screens/CreateTransfer/CreateTransferEntryScreen.tsx
@@ -1,0 +1,83 @@
+import React, { useCallback, useState } from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import { Title } from 'react-native-paper';
+import { useDispatch } from 'react-redux';
+
+import { ScanIcon } from '../../components/Icons';
+import { ScannerInput } from '../../components/ScannerInput';
+import { SearchButton } from '../../components/SearchButton';
+import { useSearchButton } from '../../components/SearchButton/useSearchButton';
+import { EMPTY_STRING } from '../../constants';
+import { navigate } from '../../NavigationService';
+import { lookupTransferBarcodeAction } from '../../redux/actions/createTransfer';
+import styles from './styles';
+
+export default function CreateTransferEntryScreen() {
+  const dispatch = useDispatch();
+  const [code, setCode] = useState<string>(EMPTY_STRING);
+  const [error, setError] = useState<string | null>(null);
+
+  const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: setCode });
+
+  const handleSubmit = useCallback(
+    (value: string) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+      setError(null);
+      dispatch(
+        lookupTransferBarcodeAction(trimmed, (result: any) => {
+          if (result?.kind === 'product') {
+            setCode(EMPTY_STRING);
+            navigate('CreateTransferItemList', {
+              productId: result.product.id,
+              productCode: result.product.productCode || trimmed
+            });
+          } else if (result?.kind === 'location') {
+            setCode(EMPTY_STRING);
+            navigate('CreateTransferItemList', {
+              binId: result.location.id,
+              binName: result.location.locationNumber || result.location.name || trimmed
+            });
+          } else if (result?.kind === 'none') {
+            setCode(EMPTY_STRING);
+            navigate('CreateTransferItemList', { searchTerm: trimmed });
+          } else {
+            setError(result?.errorMessage || 'Lookup failed. Please try again.');
+          }
+        })
+      );
+    },
+    [dispatch]
+  );
+
+  return (
+    <ScrollView keyboardShouldPersistTaps="always" style={styles.screen}>
+      <Title style={styles.title}>Scan product or bin barcode</Title>
+
+      <View style={styles.scannerRow}>
+        <ScannerInput
+          style={styles.scannerInput}
+          label="Product or Bin"
+          placeholder="Scan or type a product / bin code"
+          leftIcon={<ScanIcon size={24} />}
+          autoSubmitTimeout={400}
+          value={code}
+          isEnabled={!isSearchOpen}
+          danger={!!error}
+          onChange={(text) => {
+            setCode(text);
+            if (error) {
+              setError(null);
+            }
+          }}
+          onSubmit={handleSubmit}
+        />
+        <SearchButton searchType="productOrLocation" {...searchButtonProps} />
+      </View>
+
+      {error ? <Text style={styles.errorText}>{error}</Text> : null}
+    </ScrollView>
+  );
+}

--- a/src/screens/CreateTransfer/CreateTransferItemListScreen.tsx
+++ b/src/screens/CreateTransfer/CreateTransferItemListScreen.tsx
@@ -1,0 +1,226 @@
+import { RouteProp, useFocusEffect, useRoute } from '@react-navigation/native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { FlatList, Text, TouchableOpacity, View } from 'react-native';
+import { Chip, Divider, Paragraph } from 'react-native-paper';
+import { useDispatch, useSelector } from 'react-redux';
+
+import { ScannerInput } from '../../components/ScannerInput';
+import { EMPTY_FALLBACK, EMPTY_STRING } from '../../constants';
+import { navigate } from '../../NavigationService';
+import { getStockTransferCandidatesAction } from '../../redux/actions/createTransfer';
+import { RootState } from '../../redux/reducers';
+import CreateTransferItemRowSkeleton from './CreateTransferItemRowSkeleton';
+import styles from './styles';
+import { CreateTransferStackParams, SelectedInventoryItem, StockTransferCandidate } from './types';
+
+type ItemListRouteProp = RouteProp<CreateTransferStackParams, 'CreateTransferItemList'>;
+
+const SKELETON_ROW_COUNT = 6;
+
+type CandidateRowProps = {
+  candidate: StockTransferCandidate;
+  onPress: (candidate: StockTransferCandidate) => void;
+};
+
+function CandidateRow({ candidate, onPress }: CandidateRowProps) {
+  const productCode = candidate.product?.productCode || '-';
+  const productName = candidate.product?.name;
+  const bin = candidate.originBinLocation?.locationNumber || candidate.originBinLocation?.name || '-';
+  const lot = candidate.lotNumber ? `Lot ${candidate.lotNumber}` : '';
+  const expiry = candidate.expirationDate ? ` • Exp ${candidate.expirationDate}` : '';
+  const detail = `${lot}${expiry}`.trim();
+  const qty = candidate.quantityNotPicked ?? candidate.quantityOnHand ?? 0;
+
+  const handlePress = useCallback(() => onPress(candidate), [candidate, onPress]);
+
+  return (
+    <TouchableOpacity style={styles.candidateRow} activeOpacity={0.7} onPress={handlePress}>
+      <View style={styles.candidateRowMain}>
+        <View style={styles.candidateColProduct}>
+          <Text style={styles.candidateProduct} numberOfLines={1}>
+            {productCode}
+          </Text>
+          {productName ? (
+            <Text style={styles.candidateProductName} numberOfLines={1}>
+              {productName}
+            </Text>
+          ) : null}
+        </View>
+        <View style={styles.candidateColBin}>
+          <Text style={styles.candidateBin} numberOfLines={1}>
+            {bin}
+          </Text>
+          {detail ? (
+            <Text style={styles.candidateLot} numberOfLines={1}>
+              {detail}
+            </Text>
+          ) : null}
+        </View>
+        <View style={styles.candidateColQty}>
+          <Text style={styles.candidateQty}>{qty}</Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+export default function CreateTransferItemListScreen() {
+  const { params } = useRoute<ItemListRouteProp>();
+  const { productId, productCode, binId, binName, searchTerm: initialSearchTerm } = params || {};
+
+  const dispatch = useDispatch();
+  const currentLocation = useSelector((state: RootState) => state.mainReducer.currentLocation);
+
+  const [candidates, setCandidates] = useState<StockTransferCandidate[]>([]);
+  // filterInput tracks the controlled value; searchTerm only updates on debounced submit.
+  const [filterInput, setFilterInput] = useState<string>(initialSearchTerm ?? EMPTY_STRING);
+  const [searchTerm, setSearchTerm] = useState<string>(initialSearchTerm ?? EMPTY_STRING);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const fetchCandidates = useCallback(() => {
+    if (!currentLocation?.id) {
+      return;
+    }
+    setIsLoading(true);
+    dispatch(
+      getStockTransferCandidatesAction(
+        currentLocation.id,
+        (response: any) => {
+          setIsLoading(false);
+          if (response && !response.error && Array.isArray(response.data)) {
+            setCandidates(response.data as StockTransferCandidate[]);
+          } else {
+            setCandidates([]);
+          }
+        },
+        true
+      )
+    );
+  }, [dispatch, currentLocation?.id]);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchCandidates();
+    }, [fetchCandidates])
+  );
+
+  const filteredCandidates = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return candidates.filter((c) => {
+      if (productId && c.product?.id !== productId) {
+        return false;
+      }
+      if (binId && c.originBinLocation?.id !== binId) {
+        return false;
+      }
+      if (!term) {
+        return true;
+      }
+      const code = c.product?.productCode?.toLowerCase() || '';
+      const name = c.product?.name?.toLowerCase() || '';
+      const bin = c.originBinLocation?.locationNumber?.toLowerCase() || c.originBinLocation?.name?.toLowerCase() || '';
+      const lot = c.lotNumber?.toLowerCase() || '';
+      return code.includes(term) || name.includes(term) || bin.includes(term) || lot.includes(term);
+    });
+  }, [candidates, productId, binId, searchTerm]);
+
+  const contextLabel = useMemo(() => {
+    if (productCode) {
+      return { label: 'Product', value: productCode };
+    }
+    if (binName) {
+      return { label: 'Bin', value: binName };
+    }
+    return { label: 'Search', value: initialSearchTerm ?? EMPTY_STRING };
+  }, [productCode, binName, initialSearchTerm]);
+
+  const handleRowPress = useCallback((candidate: StockTransferCandidate) => {
+    if (!candidate?.originBinLocation?.id || !candidate?.inventoryItem?.id || !candidate?.product?.id) {
+      return;
+    }
+    const selected: SelectedInventoryItem = {
+      inventoryItemId: candidate.inventoryItem.id,
+      productAvailabilityId: candidate.productAvailabilityId,
+      product: candidate.product,
+      originBinLocation: candidate.originBinLocation,
+      lotNumber: candidate.lotNumber ?? null,
+      expirationDate: candidate.expirationDate ?? null,
+      quantityOnHand: candidate.quantityOnHand,
+      quantityNotPicked: candidate.quantityNotPicked
+    };
+    navigate('CreateTransferQuantity', { item: selected });
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: StockTransferCandidate }) => <CandidateRow candidate={item} onPress={handleRowPress} />,
+    [handleRowPress]
+  );
+
+  const handleFilterChange = useCallback((next: string) => {
+    setFilterInput(next);
+    // ScannerInput's auto-submit skips empty values; clear searchTerm eagerly.
+    if (next.trim() === '') {
+      setSearchTerm('');
+    }
+  }, []);
+
+  const keyExtractor = useCallback(
+    (c: StockTransferCandidate) => `${c.inventoryItem?.id}-${c.originBinLocation?.id}`,
+    []
+  );
+
+  const ListHeader = (
+    <>
+      <View style={[styles.productDetails]}>
+        <View style={styles.headerRow}>
+          <Chip icon="identifier" style={styles.chipDefault} textStyle={styles.chipText}>
+            {contextLabel.label}: <Text style={styles.bold}>{contextLabel.value}</Text>
+          </Chip>
+        </View>
+        <ScannerInput
+          style={styles.filterInputSpacing}
+          label="Filter"
+          placeholder="Filter by product, bin, or lot"
+          autoSubmitTimeout={400}
+          value={filterInput}
+          onChange={handleFilterChange}
+          onSubmit={setSearchTerm}
+        />
+      </View>
+
+      <Divider />
+
+      <View style={styles.tableHeader}>
+        <Text style={[styles.tableHeaderText, styles.tableHeaderProduct]}>Product</Text>
+        <Text style={[styles.tableHeaderText, styles.tableHeaderBin]}>Bin / Lot</Text>
+        <Text style={[styles.tableHeaderText, styles.tableHeaderQty]}>Qty</Text>
+      </View>
+    </>
+  );
+
+  const ListEmpty = isLoading ? (
+    <View>
+      {Array.from({ length: SKELETON_ROW_COUNT }).map((_unused, idx) => (
+        <CreateTransferItemRowSkeleton key={`skeleton-${idx}`} />
+      ))}
+    </View>
+  ) : (
+    <View style={styles.emptyTableContent}>
+      <Paragraph style={styles.emptyText}>
+        {candidates.length === 0 ? 'No inventory found.' : `No matches for "${searchTerm || EMPTY_FALLBACK}".`}
+      </Paragraph>
+    </View>
+  );
+
+  return (
+    <FlatList
+      style={styles.contentWrapper}
+      keyboardShouldPersistTaps="always"
+      data={isLoading ? [] : filteredCandidates}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListHeaderComponent={ListHeader}
+      ListEmptyComponent={ListEmpty}
+    />
+  );
+}

--- a/src/screens/CreateTransfer/CreateTransferItemRowSkeleton.tsx
+++ b/src/screens/CreateTransfer/CreateTransferItemRowSkeleton.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import { ShimmerBlock } from '../../components/ContentSkeleton';
+import styles from './styles';
+
+export default function CreateTransferItemRowSkeleton() {
+  return (
+    <View style={styles.candidateRow}>
+      <View style={styles.candidateRowMain}>
+        <View style={styles.candidateColProduct}>
+          <ShimmerBlock style={styles.skeletonLineWide} />
+          <ShimmerBlock style={styles.skeletonLineNarrow} />
+        </View>
+        <View style={styles.candidateColBin}>
+          <ShimmerBlock style={styles.skeletonLineWide} />
+          <ShimmerBlock style={styles.skeletonLineNarrow} />
+        </View>
+        <View style={styles.candidateColQty}>
+          <ShimmerBlock style={styles.skeletonLineQty} />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/screens/CreateTransfer/CreateTransferQuantityScreen.tsx
+++ b/src/screens/CreateTransfer/CreateTransferQuantityScreen.tsx
@@ -1,0 +1,112 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
+import React, { useMemo, useState } from 'react';
+import { ScrollView, View } from 'react-native';
+import { Divider, Text } from 'react-native-paper';
+
+import Button from '../../components/Button';
+import { QuantityIcon } from '../../components/Icons';
+import { ScannerInput } from '../../components/ScannerInput';
+import { EMPTY_STRING } from '../../constants';
+import { navigate } from '../../NavigationService';
+import { DetailChip } from '../../types/sortation';
+import CreateTransferDetailsPanel from './CreateTransferDetailsPanel';
+import styles from './styles';
+import { CreateTransferStackParams } from './types';
+import { formatLotExpiry } from './utils';
+
+type QuantityRouteProp = RouteProp<CreateTransferStackParams, 'CreateTransferQuantity'>;
+
+const renderQuantityIcon = () => <QuantityIcon size={16} color="#000" />;
+
+export default function CreateTransferQuantityScreen() {
+  const { params } = useRoute<QuantityRouteProp>();
+  const { item } = params;
+
+  const [quantity, setQuantity] = useState<number | undefined>(undefined);
+  const [quantityError, setQuantityError] = useState<string | null>(null);
+
+  function handleQuantityChange(text: string) {
+    const digits = text.replace(/[^0-9]/g, '');
+    setQuantity(digits.length > 0 ? parseInt(digits, 10) : undefined);
+    if (quantityError) {
+      setQuantityError(null);
+    }
+  }
+
+  function handleConfirm() {
+    if (!quantity || quantity <= 0) {
+      setQuantityError('Please enter a quantity greater than zero.');
+      return;
+    }
+    if (quantity > item.quantityNotPicked) {
+      setQuantityError(`Quantity cannot exceed available (${item.quantityNotPicked}).`);
+      return;
+    }
+    setQuantityError(null);
+    navigate('CreateTransferDestination', { item, quantity });
+  }
+
+  const detailsChips = useMemo<DetailChip[]>(
+    () => [
+      {
+        icon: 'airplane-takeoff',
+        label: 'From',
+        value: item.originBinLocation.locationNumber || item.originBinLocation.name
+      },
+      {
+        icon: 'tag',
+        label: 'Lot',
+        value: formatLotExpiry(item.lotNumber, item.expirationDate)
+      },
+      {
+        icon: renderQuantityIcon,
+        label: 'Available',
+        value: item.quantityNotPicked,
+        isActive: true
+      }
+    ],
+    [
+      item.originBinLocation.locationNumber,
+      item.originBinLocation.name,
+      item.lotNumber,
+      item.expirationDate,
+      item.quantityNotPicked
+    ]
+  );
+
+  const canConfirm = !!quantity && quantity > 0 && quantity <= item.quantityNotPicked;
+
+  return (
+    <View style={styles.screenRoot}>
+      <ScrollView keyboardShouldPersistTaps="always" style={styles.scrollContent}>
+        <CreateTransferDetailsPanel
+          productCode={item.product.productCode}
+          productName={item.product.name}
+          detailsChips={detailsChips}
+        />
+
+        <Divider />
+
+        <View style={styles.formContainer}>
+          <ScannerInput
+            showKeyboardOnMount
+            autoSubmitTimeout={0}
+            leftIcon={<QuantityIcon size={24} />}
+            placeholder={`Max ${item.quantityNotPicked}`}
+            keyboardType="number-pad"
+            label="Quantity"
+            value={quantity?.toString() ?? EMPTY_STRING}
+            danger={!!quantityError}
+            onChange={handleQuantityChange}
+            onSubmit={handleConfirm}
+          />
+          {quantityError ? <Text style={styles.errorText}>{quantityError}</Text> : null}
+        </View>
+      </ScrollView>
+
+      <View style={styles.footerContainer}>
+        <Button title="Confirm" mode="contained" size="100%" disabled={!canConfirm} onPress={handleConfirm} />
+      </View>
+    </View>
+  );
+}

--- a/src/screens/CreateTransfer/styles.ts
+++ b/src/screens/CreateTransfer/styles.ts
@@ -1,0 +1,210 @@
+import { StyleSheet } from 'react-native';
+import Theme from '../../utils/Theme';
+
+export default StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+    padding: Theme.spacing.large
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  contentWrapper: {
+    flex: 1,
+    flexDirection: 'column'
+  },
+  contentContainer: {
+    flexGrow: 1
+  },
+
+  screenRoot: {
+    flex: 1
+  },
+  scrollContent: {
+    flex: 1
+  },
+  footerContainer: {
+    paddingHorizontal: Theme.spacing.large,
+    paddingVertical: Theme.spacing.small,
+    backgroundColor: Theme.colors.surface,
+    borderTopWidth: 1,
+    borderTopColor: '#E0E0E0'
+  },
+
+  productDetails: {
+    backgroundColor: Theme.colors.surface,
+    padding: Theme.spacing.large,
+    flexDirection: 'column'
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center'
+  },
+  chipDefault: {
+    height: 28,
+    justifyContent: 'flex-start',
+    borderRadius: 4,
+    alignItems: 'center'
+  },
+  chipActive: {
+    borderWidth: 2,
+    borderColor: Theme.colors.primary
+  },
+  chipText: {
+    fontSize: 12,
+    color: Theme.colors.text
+  },
+  contentDivider: {
+    marginVertical: 8
+  },
+  title: {
+    fontSize: 18,
+    color: Theme.colors.text,
+    fontWeight: '600'
+  },
+  paragraph: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    fontWeight: 'normal'
+  },
+  paragraphMuted: {
+    fontSize: 14,
+    color: Theme.colors.disabled,
+    fontWeight: 'normal'
+  },
+  bold: { fontWeight: 'bold' },
+  caption: { fontSize: 12 },
+
+  topSpace: { marginTop: Theme.spacing.small },
+  bottomSpace: { marginBottom: Theme.spacing.small },
+  filterInputSpacing: { marginTop: Theme.spacing.small },
+
+  scannerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: Theme.spacing.small
+  },
+  scannerInput: {
+    flex: 1
+  },
+
+  formContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    paddingHorizontal: Theme.spacing.large,
+    paddingTop: Theme.spacing.small,
+    paddingBottom: Theme.spacing.medium
+  },
+
+  tableHeader: {
+    flexDirection: 'row',
+    backgroundColor: Theme.colors.primary,
+    paddingVertical: Theme.spacing.large,
+    paddingHorizontal: Theme.spacing.large,
+    marginTop: Theme.spacing.medium,
+    marginHorizontal: Theme.spacing.large,
+    alignItems: 'center'
+  },
+  tableHeaderText: {
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: '#FFFFFF'
+  },
+  tableHeaderProduct: { flex: 2 },
+  tableHeaderBin: { flex: 2, textAlign: 'left' },
+  tableHeaderQty: { flex: 1, textAlign: 'right' },
+  candidateRow: {
+    backgroundColor: '#FFFFFF',
+    paddingVertical: Theme.spacing.medium,
+    paddingHorizontal: Theme.spacing.large,
+    marginHorizontal: Theme.spacing.large,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0'
+  },
+  candidateRowMain: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  candidateColProduct: { flex: 2, paddingRight: Theme.spacing.small },
+  candidateColBin: { flex: 2, paddingRight: Theme.spacing.small },
+  candidateColQty: { flex: 1, alignItems: 'flex-end' },
+  candidateProduct: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: Theme.colors.primary
+  },
+  candidateProductName: {
+    fontSize: 12,
+    color: Theme.colors.disabled,
+    marginTop: 2
+  },
+  candidateBin: {
+    fontSize: 14,
+    color: Theme.colors.text
+  },
+  candidateLot: {
+    fontSize: 12,
+    color: Theme.colors.disabled,
+    marginTop: 2
+  },
+  candidateQty: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Theme.colors.text
+  },
+  skeletonLineWide: {
+    height: 14,
+    width: '70%',
+    borderRadius: 4,
+    marginBottom: 4
+  },
+  skeletonLineNarrow: {
+    height: 10,
+    width: '45%',
+    borderRadius: 4
+  },
+  skeletonLineQty: {
+    height: 16,
+    width: 40,
+    borderRadius: 4
+  },
+  emptyTableContent: {
+    paddingVertical: Theme.spacing.large * 2,
+    marginHorizontal: Theme.spacing.large,
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  emptyText: {
+    fontSize: 14,
+    color: Theme.colors.text,
+    textAlign: 'center'
+  },
+
+  refBand: {
+    backgroundColor: '#E8EDF2',
+    padding: Theme.spacing.medium,
+    borderRadius: 4,
+    marginBottom: Theme.spacing.medium,
+    alignItems: 'center'
+  },
+  refLabel: {
+    fontSize: 12,
+    color: Theme.colors.text,
+    marginBottom: 2
+  },
+  refValue: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    color: Theme.colors.primary
+  },
+  errorText: {
+    fontSize: 14,
+    color: Theme.colors.danger,
+    marginTop: Theme.spacing.small,
+    textAlign: 'left'
+  }
+});

--- a/src/screens/CreateTransfer/types.ts
+++ b/src/screens/CreateTransfer/types.ts
@@ -1,0 +1,78 @@
+export type StockTransferCandidate = {
+  productAvailabilityId: string;
+  product: { id: string; productCode: string; name: string };
+  inventoryItem: { id: string };
+  originBinLocation: { id: string; name: string; locationNumber?: string };
+  originZone?: string | null;
+  lotNumber: string | null;
+  expirationDate: string | null;
+  quantityOnHand: number;
+  /** QoH minus already-allocated picks — the transferable amount. */
+  quantityNotPicked: number;
+};
+
+export type SelectedInventoryItem = {
+  inventoryItemId: string;
+  productAvailabilityId: string;
+  product: { id: string; productCode: string; name: string };
+  originBinLocation: { id: string; name: string; locationNumber?: string };
+  lotNumber: string | null;
+  expirationDate: string | null;
+  quantityOnHand: number;
+  quantityNotPicked: number;
+};
+
+export type DestinationBin = {
+  id: string;
+  name: string;
+  locationNumber?: string;
+};
+
+export type BarcodeLookupResult =
+  | { kind: 'product'; product: { id: string; productCode: string; name: string } }
+  | { kind: 'location'; location: { id: string; name: string; locationNumber?: string } }
+  | { kind: 'none' };
+
+export type StockTransferPayloadItem = {
+  id: string | null;
+  productAvailabilityId: string;
+  product: { id: string };
+  inventoryItem: { id: string };
+  originBinLocation: { id: string };
+  destinationBinLocation: { id: string };
+  quantity: number;
+  quantityOnHand: number;
+  quantityNotPicked: number;
+  status: 'PENDING' | 'COMPLETED';
+  splitItems: StockTransferPayloadItem[];
+  sortOrder: number;
+};
+
+export type StockTransferPayload = {
+  stockTransferItems: StockTransferPayloadItem[];
+};
+
+export type CreateTransferStackParams = {
+  CreateTransferEntry: undefined;
+  CreateTransferItemList: {
+    productId?: string;
+    productCode?: string;
+    binId?: string;
+    binName?: string;
+    searchTerm?: string;
+  };
+  CreateTransferQuantity: {
+    item: SelectedInventoryItem;
+  };
+  CreateTransferDestination: {
+    item: SelectedInventoryItem;
+    quantity: number;
+  };
+  CreateTransferComplete: {
+    transferId: string;
+    stockTransferNumber: string;
+    item: SelectedInventoryItem;
+    quantity: number;
+    destination: DestinationBin;
+  };
+};

--- a/src/screens/CreateTransfer/utils.ts
+++ b/src/screens/CreateTransfer/utils.ts
@@ -1,0 +1,15 @@
+import { EMPTY_FALLBACK } from '../../constants';
+
+export function formatLotExpiry(lot: string | null, expiry: string | null): string {
+  if (lot && expiry) {
+    return `${lot} • Exp ${expiry}`;
+  }
+  return lot || expiry || EMPTY_FALLBACK;
+}
+
+export const STOCK_TRANSFER_STATUS = {
+  PENDING: 'PENDING',
+  COMPLETED: 'COMPLETED'
+} as const;
+
+export type StockTransferStatus = (typeof STOCK_TRANSFER_STATUS)[keyof typeof STOCK_TRANSFER_STATUS];

--- a/src/screens/Dashboard/dashboardData.ts
+++ b/src/screens/Dashboard/dashboardData.ts
@@ -151,6 +151,14 @@ const dashboardEntries: DashboardEntry[] = [
     group: 'INVENTORY'
   },
   {
+    key: 'createTransfer',
+    screenName: 'Create Transfer',
+    entryDescription: 'Create a new internal stock transfer',
+    icon: IconPendingTransfers,
+    navigationScreenName: 'CreateTransferEntry',
+    group: 'INVENTORY'
+  },
+  {
     key: 'cycleCount',
     screenName: 'Cycle Count',
     entryDescription: 'Manage inventory cycle counts',


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-736

  Adds a self-contained "Create Transfer" flow to the mobile app, reachable from a new dashboard tile. Lets a warehouse user scan a product or bin, pick an inventory item, enter a quantity, choose a destination bin, and complete the transfer.

  ## Summary
  - New dashboard tile **Create Transfer** opens a 4-step flow:
    - **Entry** - scan product or bin barcode, or search via the modal.
    - **Item list** - candidate `InventoryItem` rows (product · bin · lot · qty) filtered by the resolved product/bin, with a debounced filter input.
    - **Quantity** - read-only context panel + numeric input capped at the inventory item's `quantityNotPicked`.
    - **Destination** - destination bin scan/search, then submit.
    - **Complete** - one-tap PUT to flip the PENDING transfer to COMPLETED, success morphs the button to "New Transfer".


https://github.com/user-attachments/assets/16689017-7fbb-4496-9ab5-71bf69fd337f