### PR TITLE
OBLS-740 Show lost and found banner when canceling remaining qty

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -15,7 +15,8 @@ export enum Name {
   Check,
   ChevronRight,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  Warning
 }
 
 export interface Props {
@@ -58,6 +59,9 @@ export default function Icon(props: Props) {
       break;
     case Name.ChevronUp:
       content = <Entypo name="chevron-up" style={props.style} size={props.size} color={props.color} />;
+      break;
+    case Name.Warning:
+      content = <MaterialIcons name="warning" style={props.style} size={props.size} color={props.color} />;
       break;
   }
 

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import AsyncModalSelect from '../../components/AsyncModalSelect';
 import Button from '../../components/Button';
 import EmptyView from '../../components/EmptyView';
+import Icon, { Name as IconName } from '../../components/Icon';
 import { QuantityIcon } from '../../components/Icons';
 import { ScannerInput } from '../../components/ScannerInput';
 import { navigate, replace } from '../../NavigationService';
@@ -288,6 +289,15 @@ export default function PutawayQuantityScreen() {
               onValueChange={handleCancelRemainingToggle}
             />
           </View>
+
+          {isCancelRemainingEnabled && remainingQty > 0 && (
+            <View style={styles.lostAndFoundBanner}>
+              <Icon name={IconName.Warning} size={20} color={Theme.colors.warningText} />
+              <Paragraph style={styles.lostAndFoundBannerText}>
+                The remaining {remainingQty} will be recorded as Lost & Found upon submission.
+              </Paragraph>
+            </View>
+          )}
         </View>
 
         <View style={styles.bottomActionContainer}>

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -111,6 +111,20 @@ export default StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center'
   },
+  lostAndFoundBanner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: Theme.colors.warning,
+    padding: Theme.spacing.medium,
+    borderRadius: 4,
+    marginTop: Theme.spacing.small
+  },
+  lostAndFoundBannerText: {
+    fontSize: 14,
+    color: Theme.colors.warningText,
+    flex: 1,
+    marginLeft: Theme.spacing.medium
+  },
   dialogActions: {
     flexDirection: 'row',
     justifyContent: 'flex-end'


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-740

Changes:
- When Cancel Remaining is enabled, the BE silently routes the canceled quantity to Lost & Found. The UI now surfaces this explicitly with a warning-style banner under the toggle so the user can see the L&F adjustment before submitting.

<img width="371" height="391" alt="image" src="https://github.com/user-attachments/assets/3d56ea91-3d32-4e41-88a7-83a2fc43c32a" />
