### PR TITLE
OBLS-741 Block canceling qty if remaining is 0

### DIFF
--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -79,6 +79,15 @@ export default function PutawayQuantityScreen() {
     setPutawayQuantity(undefined);
   }, [isFocused]);
 
+  const remainingQty = Math.max((putawayDetails?.quantity ?? 0) - (putawayQuantity ?? 0), 0);
+  const isCancelRemainingDisabled = remainingQty === 0;
+
+  useEffect(() => {
+    if (isCancelRemainingDisabled && isCancelRemainingEnabled) {
+      setIsCancelRemainingEnabled(false);
+    }
+  }, [isCancelRemainingDisabled, isCancelRemainingEnabled]);
+
   if (!putawayDetails) {
     return (
       <View style={styles.emptyContainer}>
@@ -230,8 +239,6 @@ export default function PutawayQuantityScreen() {
     destination: selectedAlternativeDestination ?? putawayDetails?.destination
   };
 
-  const remainingQty = Math.max(putawayDetails.quantity - (putawayQuantity ?? 0), 0);
-
   return (
     <Portal.Host>
       <ScrollView keyboardShouldPersistTaps="always" style={styles.contentContainer}>
@@ -281,10 +288,13 @@ export default function PutawayQuantityScreen() {
           </View>
 
           <View style={styles.cardAnnotation}>
-            <Paragraph style={styles.subheading}>Cancel Remaining ({remainingQty})</Paragraph>
+            <Paragraph style={[styles.subheading, isCancelRemainingDisabled && styles.subheadingDisabled]}>
+              Cancel Remaining ({remainingQty})
+            </Paragraph>
             <Switch
               value={isCancelRemainingEnabled}
               color={Theme.colors.primary}
+              disabled={isCancelRemainingDisabled}
               onValueChange={handleCancelRemainingToggle}
             />
           </View>

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -61,6 +61,9 @@ export default StyleSheet.create({
     color: Theme.colors.text,
     fontWeight: 'bold'
   },
+  subheadingDisabled: {
+    color: Theme.colors.disabled
+  },
   caption: { fontSize: 12 },
   bold: { fontWeight: 'bold' },
   paragraph: {


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-741

Changes:
-  At full counted qty (e.g. 20/20), the Cancel Remaining toggle remained interactive, allowing the meaningless Cancel Remaining (0) state. The Switch is now disabled when remainingQty === 0, the label uses a muted style, and any previously-on state is reset.

<img width="366" height="344" alt="image" src="https://github.com/user-attachments/assets/9556c478-0803-401d-b6f0-a088e068a12a" />
