### PR TITLE
OBLS-742 Hide discrepancy reason dropdown until a discrepancy exists

### DIFF
--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -79,6 +79,15 @@ export default function PutawayQuantityScreen() {
     setPutawayQuantity(undefined);
   }, [isFocused]);
 
+  const hasDiscrepancy =
+    (putawayQuantity !== undefined && putawayQuantity < (putawayDetails?.quantity ?? 0)) || isCancelRemainingEnabled;
+
+  useEffect(() => {
+    if (!hasDiscrepancy && selectedReasonCode) {
+      setSelectedReasonCode(null);
+    }
+  }, [hasDiscrepancy, selectedReasonCode]);
+
   if (!putawayDetails) {
     return (
       <View style={styles.emptyContainer}>
@@ -110,8 +119,6 @@ export default function PutawayQuantityScreen() {
       );
       return;
     }
-
-    const hasDiscrepancy = putawayQuantity < totalQty || isCancelRemainingEnabled;
 
     if (hasDiscrepancy && !selectedReasonCode?.id) {
       Alert.alert('Discrepancy Reason Required', 'Please select a discrepancy reason.');
@@ -263,21 +270,22 @@ export default function PutawayQuantityScreen() {
               <Button size="50%" title="Request" onPress={() => setIsDialogVisible(true)} />
             </View>
 
-            <View style={styles.headerRow}>
-              <Paragraph style={styles.subheading}>Discrepancy Reason</Paragraph>
-              <View style={styles.dropdownContainer}>
-                <AsyncModalSelect
-                  placeholder="Select a reason"
-                  label="Reason for shortage"
-                  initValue={selectedReasonCode?.name || ''}
-                  initialData={reasonCodes}
-                  searchAction={() => {}}
-                  serverSearchEnabled={false}
-                  disabled={!isCancelRemainingEnabled && putawayQuantity === putawayDetails.quantity}
-                  onSelect={(reason: ReasonCode) => setSelectedReasonCode(reason)}
-                />
+            {hasDiscrepancy && (
+              <View style={styles.headerRow}>
+                <Paragraph style={styles.subheading}>Discrepancy Reason</Paragraph>
+                <View style={styles.dropdownContainer}>
+                  <AsyncModalSelect
+                    placeholder="Select a reason"
+                    label="Reason for shortage"
+                    initValue={selectedReasonCode?.name || ''}
+                    initialData={reasonCodes}
+                    searchAction={() => {}}
+                    serverSearchEnabled={false}
+                    onSelect={(reason: ReasonCode) => setSelectedReasonCode(reason)}
+                  />
+                </View>
               </View>
-            </View>
+            )}
           </View>
 
           <View style={styles.cardAnnotation}>


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-742

Changes:
- The Discrepancy Reason dropdown was always rendered, even when counts matched. It now appears only when a discrepancy exists (partial qty), and any previously selected reason is cleared when the discrepancy resolves.

No Discrepancy:
<img width="369" height="267" alt="image" src="https://github.com/user-attachments/assets/15795b0c-c3de-4273-94e1-39f83dbde011" />

Discrepancy:
<img width="368" height="337" alt="image" src="https://github.com/user-attachments/assets/0647f076-c8ef-4094-84ae-04148879de2c" />

