### PR TITLE
OBLS-744 Require minimum 3 chars before triggering product/location l…

### DIFF
--- a/src/components/SearchButton/index.tsx
+++ b/src/components/SearchButton/index.tsx
@@ -30,7 +30,8 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
   const provider = searchProviders[searchType];
 
   const performSearch = (term: string) => {
-    if (!term.trim()) {
+    const trimmed = term.trim();
+    if (trimmed.length < appConfig.MIN_SEARCH_LENGTH) {
       setResults([]);
       setLoading(false);
       setHasSearched(false);
@@ -75,6 +76,12 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
   const handleChangeText = (text: string) => {
     setSearchTerm(text);
     setHasSearched(false);
+    if (text.trim().length < appConfig.MIN_SEARCH_LENGTH) {
+      debouncedSearch.cancel();
+      setResults([]);
+      setLoading(false);
+      return;
+    }
     debouncedSearch(text);
   };
 
@@ -135,17 +142,21 @@ export function SearchButton({ searchType, onSelect, onOpen, onClose }: SearchBu
               <SkeletonList />
             ) : (
               <>
-                {searchTerm.trim() === '' && results.length === 0 && (
-                  <Text style={styles.hintText}>Start typing to search...</Text>
-                )}
-
-                {results.length > 0 && (
-                  <Text style={styles.resultCount}>
-                    {results.length} result{results.length !== 1 ? 's' : ''} found.
+                {searchTerm.trim().length < appConfig.MIN_SEARCH_LENGTH ? (
+                  <Text style={styles.hintText}>
+                    Type at least {appConfig.MIN_SEARCH_LENGTH} characters to search...
                   </Text>
-                )}
+                ) : (
+                  <>
+                    {results.length > 0 && (
+                      <Text style={styles.resultCount}>
+                        {results.length} result{results.length !== 1 ? 's' : ''} found.
+                      </Text>
+                    )}
 
-                {hasSearched && results.length === 0 && <Text style={styles.emptyText}>No results found.</Text>}
+                    {hasSearched && results.length === 0 && <Text style={styles.emptyText}>No results found.</Text>}
+                  </>
+                )}
               </>
             )}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const DEFAULT_DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
 export const appConfig = {
   DEFAULT_DEBOUNCE_TIME: 100,
   DEFAULT_SEARCH_DEBOUNCE_TIME: 800,
+  MIN_SEARCH_LENGTH: 3,
   APP_HEADER_HEIGHT: 56,
   LOCALE: 'en-US'
 };


### PR DESCRIPTION
…ookups

https://openboxes.atlassian.net/browse/OBLS-744

The product/location typeahead in `SearchButton` currently fires a lookup on every keystroke, which fetches the full unpaginated dataset (~13k products / ~5k locations on VVG). This PR gates the lookup behind a `MIN_SEARCH_LENGTH` threshold and surfaces a clear hint to the user while below it.

<img width="345" height="155" alt="image" src="https://github.com/user-attachments/assets/15515327-d90a-4b12-83cf-7e84993f3472" />
<img width="345" height="155" alt="image" src="https://github.com/user-attachments/assets/ceb9c5e2-724d-4db5-b903-46572a2a9ba8" />
<img width="342" height="266" alt="image" src="https://github.com/user-attachments/assets/5f8020ce-2ff2-497e-9b4e-b7a336c979c9" />
