### PR TITLE
OBLS-745 Paginate Products list and gate search at 3 chars

### DIFF
--- a/src/apis/products.ts
+++ b/src/apis/products.ts
@@ -1,7 +1,22 @@
 import apiClient from '../utils/ApiClient';
 
-export function getProducts() {
-  return apiClient.get('/generic/product');
+export interface PaginationParams {
+  max?: number;
+  offset?: number;
+}
+
+export function getProducts(pagination?: PaginationParams) {
+  const params: string[] = [];
+
+  if (pagination?.max !== undefined) {
+    params.push(`max=${pagination.max}`);
+  }
+  if (pagination?.offset !== undefined) {
+    params.push(`offset=${pagination.offset}`);
+  }
+
+  const qs = params.length ? `?${params.join('&')}` : '';
+  return apiClient.get(`/generic/product${qs}`);
 }
 
 export function searchProductsByName(name: string) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,13 @@ export const appConfig = {
   DEFAULT_SEARCH_DEBOUNCE_TIME: 800,
   DEFAULT_PAGE_SIZE: 25,
   MIN_SEARCH_LENGTH: 3,
+  /**
+   * Distance from the end of the loaded list at which `FlatList.onEndReached`
+   * fires, expressed as a multiplier of the visible viewport length (not a
+   * fixed item count). e.g. `2` means the callback triggers when the user is
+   * within two viewport-heights of the end of the loaded content.
+   */
+  LIST_END_REACHED_THRESHOLD: 2,
   APP_HEADER_HEIGHT: 56,
   LOCALE: 'en-US'
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,8 @@ export const DEFAULT_DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
 export const appConfig = {
   DEFAULT_DEBOUNCE_TIME: 100,
   DEFAULT_SEARCH_DEBOUNCE_TIME: 800,
+  DEFAULT_PAGE_SIZE: 25,
+  MIN_SEARCH_LENGTH: 3,
   APP_HEADER_HEIGHT: 56,
   LOCALE: 'en-US'
 };

--- a/src/redux/actions/products.ts
+++ b/src/redux/actions/products.ts
@@ -38,9 +38,14 @@ export const UPDATE_PRODUCT_IDENTIFIER_REQUEST = 'UPDATE_PRODUCT_IDENTIFIER_REQU
 export const UPDATE_PRODUCT_IDENTIFIER_SUCCESS = 'UPDATE_PRODUCT_IDENTIFIER_SUCCESS';
 export const UPDATE_PRODUCT_IDENTIFIER_FAIL = 'UPDATE_PRODUCT_IDENTIFIER_FAIL';
 
-export function getProductsAction(callback?: (products: any) => void, suppressLoading?: boolean) {
+export function getProductsAction(
+  callback?: (products: any) => void,
+  suppressLoading?: boolean,
+  pagination?: { max?: number; offset?: number }
+) {
   return {
     type: GET_PRODUCTS_REQUEST,
+    payload: { pagination },
     callback,
     suppressLoading
   };

--- a/src/redux/sagas/products.ts
+++ b/src/redux/sagas/products.ts
@@ -32,7 +32,7 @@ function* getProducts(action: any) {
     if (!action.suppressLoading) {
       yield put(showScreenLoading('Loading..'));
     }
-    const response = yield call(api.getProducts);
+    const response = yield call(api.getProducts, action.payload?.pagination);
     yield put({
       type: GET_PRODUCTS_REQUEST_SUCCESS,
       payload: response.data

--- a/src/screens/Products/ProductsList.tsx
+++ b/src/screens/Products/ProductsList.tsx
@@ -1,5 +1,13 @@
 import React, { ReactElement } from 'react';
-import { FlatList, ListRenderItemInfo, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItemInfo,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View
+} from 'react-native';
 import { Card, Chip, Divider, Subheading } from 'react-native-paper';
 
 import { LayoutStyle } from '../../assets/styles';
@@ -11,21 +19,49 @@ import Theme from '../../utils/Theme';
 export interface Props {
   products: Product[] | null;
   onProductTapped: (product: Product) => void;
+  onEndReached?: () => void;
+  loadingMore?: boolean;
+  hasMore?: boolean;
 }
 
 export default function ProductsList(props: Props) {
-  return props.products ? (
+  const { products, onProductTapped, onEndReached, loadingMore, hasMore } = props;
+
+  if (!products) {
+    return <EmptyView title="Product List" description="There are no products on the list" />;
+  }
+
+  const renderFooter = () => {
+    if (loadingMore) {
+      return (
+        <View style={styles.footer}>
+          <ActivityIndicator size="small" color={Theme.colors.primary} />
+        </View>
+      );
+    }
+
+    if (hasMore === false && (products?.length ?? 0) > 0) {
+      return (
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>End of list</Text>
+        </View>
+      );
+    }
+
+    return null;
+  };
+
+  return (
     <FlatList
-      data={props.products}
-      renderItem={(item: ListRenderItemInfo<Product>) =>
-        renderProduct(item.item, () => props.onProductTapped(item.item))
-      }
+      data={products}
+      renderItem={(item: ListRenderItemInfo<Product>) => renderProduct(item.item, () => onProductTapped(item.item))}
       keyExtractor={(product) => product.id}
       style={styles.list}
       keyboardShouldPersistTaps="handled"
+      ListFooterComponent={renderFooter}
+      onEndReached={onEndReached}
+      onEndReachedThreshold={0.5}
     />
-  ) : (
-    <EmptyView title="Product List" description="There are no products on the list" />
   );
 }
 
@@ -61,6 +97,14 @@ function renderProduct(product: Product, onProductTapped: () => void): ReactElem
 const styles = StyleSheet.create({
   list: {
     width: '100%'
+  },
+  footer: {
+    paddingBottom: Theme.spacing.medium,
+    alignItems: 'center'
+  },
+  footerText: {
+    fontSize: 13,
+    color: Theme.colors.secondaryForeground
   },
   subheading: {
     fontWeight: 'bold',

--- a/src/screens/Products/ProductsList.tsx
+++ b/src/screens/Products/ProductsList.tsx
@@ -12,7 +12,7 @@ import { Card, Chip, Divider, Subheading } from 'react-native-paper';
 
 import { LayoutStyle } from '../../assets/styles';
 import EmptyView from '../../components/EmptyView';
-import { HYPHEN } from '../../constants';
+import { appConfig, HYPHEN } from '../../constants';
 import Product from '../../data/product/Product';
 import Theme from '../../utils/Theme';
 
@@ -60,7 +60,7 @@ export default function ProductsList(props: Props) {
       keyboardShouldPersistTaps="handled"
       ListFooterComponent={renderFooter}
       onEndReached={onEndReached}
-      onEndReachedThreshold={0.5}
+      onEndReachedThreshold={appConfig.LIST_END_REACHED_THRESHOLD}
     />
   );
 }

--- a/src/screens/Products/VM.ts
+++ b/src/screens/Products/VM.ts
@@ -9,4 +9,7 @@ export interface VM {
   list: Product[] | null;
   floatingActionButtonVisible: boolean;
   centralErrorMessage: string | null;
+  showingAllProducts: boolean;
+  allProductsHasMore: boolean;
+  loadingMore: boolean;
 }

--- a/src/screens/Products/VMMapper.ts
+++ b/src/screens/Products/VMMapper.ts
@@ -7,6 +7,7 @@ export default function vmMapper(state: State): VM {
     subtitle = `Products in category \"${state.searchByCategory.category.name}\"`;
   }
   let list = null;
+  let showingAllProducts = false;
   if (state.error === null) {
     if (
       state.searchByCategory &&
@@ -30,6 +31,7 @@ export default function vmMapper(state: State): VM {
       list = state.searchGlobally.results;
     } else {
       list = state.allProducts;
+      showingAllProducts = true;
     }
   }
   let floatingActionButtonVisible = true;
@@ -48,6 +50,9 @@ export default function vmMapper(state: State): VM {
     list: list,
     floatingActionButtonVisible: floatingActionButtonVisible,
     centralErrorMessage: centralErrorMessage,
-    barcodeNo: state.barcodeNo
+    barcodeNo: state.barcodeNo,
+    showingAllProducts,
+    allProductsHasMore: state.allProductsHasMore,
+    loadingMore: state.loadingMore
   };
 }

--- a/src/screens/Products/index.tsx
+++ b/src/screens/Products/index.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { View } from 'react-native';
 import { connect } from 'react-redux';
 
+import BarcodeSearchHeader from '../../components/BarcodeSearchHeader/BarcodeSearchHeader';
 import ListLoadingSkeleton from '../../components/ListLoadingSkeleton';
 import showPopup from '../../components/Popup';
-import BarcodeSearchHeader from '../../components/BarcodeSearchHeader/BarcodeSearchHeader';
 import { appConfig } from '../../constants';
 import { ProductCategory } from '../../data/product/category/ProductCategory';
+import Product from '../../data/product/Product';
 import {
   getProductsAction,
   searchProductByCodeAction,
@@ -79,7 +80,7 @@ class Products extends React.Component<Props, State> {
         });
         return;
       }
-      const items: any[] = Array.isArray(data) ? data : [];
+      const items: Product[] = Array.isArray(data) ? data : [];
       this.setState((prev) => {
         const baseList = offset === 0 ? [] : prev.allProducts ?? [];
         const merged = [...baseList, ...items];
@@ -112,7 +113,7 @@ class Products extends React.Component<Props, State> {
     this.fetchProductsPage(loaded);
   };
 
-  goToProductDetails = (product: any) => {
+  goToProductDetails = (product: Product) => {
     this.props.navigation.navigate('ProductDetails', {
       product,
       fromSortation: this.props.route?.params?.fromSortation

--- a/src/screens/Products/index.tsx
+++ b/src/screens/Products/index.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import ListLoadingSkeleton from '../../components/ListLoadingSkeleton';
 import showPopup from '../../components/Popup';
 import BarcodeSearchHeader from '../../components/BarcodeSearchHeader/BarcodeSearchHeader';
+import { appConfig } from '../../constants';
 import { ProductCategory } from '../../data/product/category/ProductCategory';
 import {
   getProductsAction,
@@ -32,6 +33,8 @@ class Products extends React.Component<Props, State> {
       searchGlobally: null,
       error: null,
       allProducts: null,
+      allProductsHasMore: true,
+      loadingMore: false,
       searchBoxVisible: false,
       searchBoxProductCodeVisible: false,
       categoryPickerPopupVisible: false,
@@ -49,29 +52,64 @@ class Products extends React.Component<Props, State> {
   };
 
   getProducts = () => {
-    this.setState({ loading: true, searchTerm: '' });
+    this.setState({
+      loading: true,
+      searchTerm: '',
+      allProducts: [],
+      allProductsHasMore: true,
+      loadingMore: false
+    });
+    this.fetchProductsPage(0);
+  };
+
+  fetchProductsPage = (offset: number) => {
     const actionCallback = (data: any) => {
-      this.setState({ loading: false });
       if (data?.error) {
+        this.setState({ loading: false, loadingMore: false });
         showPopup({
           title: data.errorMessage ? 'Failed to fetch products' : 'Error',
           message: data.errorMessage ?? 'Failed to fetch products',
           positiveButton: {
             text: 'Retry',
             callback: () => {
-              this.getProducts();
+              this.fetchProductsPage(offset);
             }
           },
           negativeButtonText: 'Cancel'
         });
         return;
       }
-      this.setState({
-        error: data?.length === 0 ? emptyStateMessage('products', '', 'No products available') : null,
-        allProducts: data ?? []
+      const items: any[] = Array.isArray(data) ? data : [];
+      this.setState((prev) => {
+        const baseList = offset === 0 ? [] : prev.allProducts ?? [];
+        const merged = [...baseList, ...items];
+        return {
+          loading: false,
+          loadingMore: false,
+          allProducts: merged,
+          allProductsHasMore: items.length === appConfig.DEFAULT_PAGE_SIZE,
+          error: merged.length === 0 ? emptyStateMessage('products', '', 'No products available') : null
+        };
       });
     };
-    this.props.getProductsAction(actionCallback, true);
+
+    this.props.getProductsAction(actionCallback, true, {
+      max: appConfig.DEFAULT_PAGE_SIZE,
+      offset
+    });
+  };
+
+  loadMoreProducts = () => {
+    const { allProducts, allProductsHasMore, loadingMore, loading } = this.state;
+    if (loading || loadingMore || !allProductsHasMore) {
+      return;
+    }
+    const loaded = allProducts?.length ?? 0;
+    if (loaded === 0) {
+      return;
+    }
+    this.setState({ loadingMore: true });
+    this.fetchProductsPage(loaded);
   };
 
   goToProductDetails = (product: any) => {
@@ -270,10 +308,28 @@ class Products extends React.Component<Props, State> {
   };
 
   onSearchTermSubmit = (query: string) => {
-    if (!query) {
+    const trimmed = query.trim();
+
+    if (trimmed.length === 0) {
       this.setState({
-        searchByProductCode: { query: '', results: this.state.allProducts },
+        searchByName: null,
+        searchByProductCode: null,
+        searchByCategory: null,
+        searchGlobally: null,
         searchTerm: '',
+        error: null
+      });
+      this.getProducts();
+      return;
+    }
+
+    if (trimmed.length < appConfig.MIN_SEARCH_LENGTH) {
+      this.setState({
+        searchByName: null,
+        searchByProductCode: null,
+        searchByCategory: null,
+        searchGlobally: null,
+        searchTerm: trimmed,
         error: null
       });
       return;
@@ -338,7 +394,7 @@ class Products extends React.Component<Props, State> {
         <BarcodeSearchHeader
           autoSearch
           autoFocus
-          placeholder={'Search by product code or name'}
+          placeholder={`Search products (min ${appConfig.MIN_SEARCH_LENGTH} chars)`}
           subtitle={vm.subtitle}
           resetSearch={this.getProducts}
           searchBox={false}
@@ -351,7 +407,13 @@ class Products extends React.Component<Props, State> {
             <ListLoadingSkeleton visible count={5} CardComponent={ProductCardSkeleton} />
           ) : (
             <>
-              <ProductsList products={vm.list} onProductTapped={this.goToProductDetails} />
+              <ProductsList
+                products={vm.list}
+                loadingMore={vm.showingAllProducts && vm.loadingMore}
+                hasMore={vm.showingAllProducts ? vm.allProductsHasMore : undefined}
+                onProductTapped={this.goToProductDetails}
+                onEndReached={vm.showingAllProducts ? this.loadMoreProducts : undefined}
+              />
               {vm?.list?.length === 0 && <CentralMessage message={vm.centralErrorMessage} />}
             </>
           )}

--- a/src/screens/Products/types.ts
+++ b/src/screens/Products/types.ts
@@ -12,27 +12,19 @@ export interface StateProps {
 }
 
 export interface DispatchProps {
-  getProductsAction: (callback: (products: any) => void, suppressLoading?: boolean) => void;
+  getProductsAction: (
+    callback: (products: any) => void,
+    suppressLoading?: boolean,
+    pagination?: { max?: number; offset?: number }
+  ) => void;
   searchProductsByNameAction: (
     name: string,
     callback: (searchedProducts: any) => void,
     suppressLoading?: boolean
   ) => void;
-  searchProductByCodeAction: (
-    productCode: string,
-    callback: (data: any) => void,
-    suppressLoading?: boolean
-  ) => void;
-  searchProductGloballyAction: (
-    value: string,
-    callback: (data: any) => void,
-    suppressLoading?: boolean
-  ) => void;
-  searchProductSByCategoryAction: (
-    category: any,
-    callback: (data: any) => void,
-    suppressLoading?: boolean
-  ) => void;
+  searchProductByCodeAction: (productCode: string, callback: (data: any) => void, suppressLoading?: boolean) => void;
+  searchProductGloballyAction: (value: string, callback: (data: any) => void, suppressLoading?: boolean) => void;
+  searchProductSByCategoryAction: (category: any, callback: (data: any) => void, suppressLoading?: boolean) => void;
 }
 
 export type Props = OwnProps & StateProps & DispatchProps;
@@ -40,6 +32,8 @@ export type Props = OwnProps & StateProps & DispatchProps;
 export interface State {
   error: string | null;
   allProducts: Product[] | null;
+  allProductsHasMore: boolean;
+  loadingMore: boolean;
   searchBoxVisible: boolean;
   searchBoxProductCodeVisible: boolean;
   categoryPickerPopupVisible: boolean;


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-745

Replaces the single fetch of the full product catalogue on the Products screen with a paginated `?max=25&offset=N` flow. End-of-list is inferred client-side from page-size match - no backend changes needed since `/api/generic/product` already accepts `max`/`offset`.

Also gates the top-bar search to a 3-character minimum to avoid sending sub-threshold queries; the placeholder communicates the requirement.

<img width="371" height="592" alt="image" src="https://github.com/user-attachments/assets/5d986928-5438-4224-991e-c772c1b88872" />

The performance of the Products page has improved, the loading time from ~15-20s -> 1s.

Edit: Bump FlatList `onEndReachedThreshold` from 0.5 to 2 so the next page is prefetched when the user is mid-page on a typical phone, hiding network latency behind continued scrolling. Threshold lives in appConfig for tuning.