### PR TITLE
OBLS-754 Make User Directed product input filter-only

### DIFF
--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,6 +1,6 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Button, Chip, Divider, Paragraph } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
@@ -139,19 +139,6 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
       tasks
     }));
   }, [filteredTasks]);
-
-  useEffect(() => {
-    if (searchTerm.trim() && filteredTasks.length === 1) {
-      const matchedTask = filteredTasks[0];
-      const globalIndex = putawayTasks.findIndex((t) => t.id === matchedTask.id);
-      setSearchTerm('');
-      navigation.navigate('SortationPutawayLocationScan', {
-        currentTaskIndex: globalIndex >= 0 ? globalIndex : 0,
-        isUserDirected: true,
-        containerId
-      });
-    }
-  }, [searchTerm, filteredTasks, putawayTasks, navigation, containerId]);
 
   const isSearching = searchTerm.trim().length > 0;
 


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-754

## Changes
  - Remove auto-navigation from PutawayTaskListScreen when the product filter collapsed to a single match - the input is now purely a filter, matching the visible affordance.
  - User Directed navigation still happens explicitly via tapping a task row; System Directed flow is unaffected (it never routes through this screen).