### PR TITLE
OBLS-756 Clear Putaway Product Scan input when navigating to a new task

### DIFF
--- a/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayProductScanScreen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Alert, ScrollView, View } from 'react-native';
 import { Divider, Subheading } from 'react-native-paper';
 import { useSelector } from 'react-redux';
@@ -38,6 +38,10 @@ export default function PutawayProductScanScreen() {
   const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
   const [putawayProductBarcode, setPutawayProductBarcode] = useState<string>(EMPTY_STRING);
   const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: setPutawayProductBarcode });
+
+  useEffect(() => {
+    setPutawayProductBarcode(EMPTY_STRING);
+  }, [currentTaskIndex, putawayDetails?.id]);
 
   if (!putawayDetails) {
     return (


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-756

## Changes
  - Reset the product barcode input on PutawayProductScanScreen when the active task changes, so re-entering the screen for a new task (e.g. the remaining task created by a partial putaway) shows an empty field instead of the previously scanned value.
  - Mirrors the existing reset pattern in PutawayLocationScanScreen (keyed on currentTaskIndex and putawayDetails.id).


https://github.com/user-attachments/assets/c8f52704-5bc9-49fe-ad7e-202a033480f4

