### PR TITLE
OBLS-697 Propagate alternative putaway location from Location Scan to…

### DIFF
--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -63,6 +63,11 @@ export default function PutawayLocationScanScreen() {
     );
   }
 
+  const updatedPutawayDetails = {
+    ...putawayDetails,
+    destination: selectedAlternativeDestination ?? putawayDetails.destination
+  };
+
   function handleProcessing(code: string) {
     const expectedLocation = selectedAlternativeDestination?.locationNumber;
 
@@ -80,14 +85,9 @@ export default function PutawayLocationScanScreen() {
       isDirectPutaway,
       isUserDirected,
       containerId,
-      task
+      task: updatedPutawayDetails
     });
   }
-
-  const updatedPutawayDetails = {
-    ...putawayDetails,
-    destination: selectedAlternativeDestination ?? putawayDetails.destination
-  };
 
   return (
     <>
@@ -137,7 +137,7 @@ export default function PutawayLocationScanScreen() {
             Submit
           </Button>
 
-          {task ? null : isUserDirected ? (
+          {isDirectPutaway ? null : isUserDirected ? (
             <Button
               style={styles.topSpace}
               title="Back To List"

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -38,6 +38,7 @@ type ReasonCode = {
   name: string;
 };
 
+// eslint-disable-next-line complexity
 export default function PutawayQuantityScreen() {
   const { params } = useRoute<PutawayQuantityRouteProp>();
   const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task } = params;
@@ -56,10 +57,6 @@ export default function PutawayQuantityScreen() {
   const [isCancelRemainingEnabled, setIsCancelRemainingEnabled] = useState<boolean>(false);
 
   const [isDialogVisible, setIsDialogVisible] = useState(false);
-
-  useEffect(() => {
-    setSelectedAlternativeDestination(putawayDetails?.destination);
-  }, [putawayDetails]);
 
   useEffect(() => {
     dispatch(
@@ -182,7 +179,7 @@ export default function PutawayQuantityScreen() {
               handleResponseAfterComplete
             )
           );
-        } else if (task) {
+        } else if (isDirectPutaway) {
           // Direct Putaway: partial done, remaining task lives on backend
           navigate('Sortation');
         } else if (isUserDirected && containerId) {
@@ -215,7 +212,7 @@ export default function PutawayQuantityScreen() {
     if (response && !response.error) {
       Alert.alert('Putaway Successful', 'The putaway was successful.');
 
-      if (task) {
+      if (isDirectPutaway) {
         // Direct Putaway: single task done, go back to Sortation
         navigate('Sortation');
       } else if (isUserDirected && containerId) {


### PR DESCRIPTION
… Quantity

https://openboxes.atlassian.net/browse/OBLS-697

## Changes
  - Propagate the alternative destination chosen on `PutawayLocationScanScreen` through to `PutawayProductScanScreen` and `PutawayQuantityScreen`, so the submitted payload carries the alternative location instead of the original one.
  - Decouple the "Direct Putaway" signal from the `task` route param: the two `if (task)` branches in `PutawayQuantityScreen` now check `isDirectPutaway` explicitly, freeing the`task` param to carry the (possibly destination-overridden) task data across screens.
  - Drop the sync effect in `PutawayQuantityScreen` that was resetting `selectedAlternativeDestination` back to `putawayDetails.destination` whenever the `putawayDetails` reference changed.
- Works for User Directed and System Directed flows.


https://github.com/user-attachments/assets/a61a2d53-02a4-4b7a-84da-f146bb43384d

After Putaway (previously no quantity in DIS01B)
<img width="1056" height="304" alt="image" src="https://github.com/user-attachments/assets/20f7e556-5b06-4349-8378-92e14ad307bc" />

