### PR TITLE
OBLS-558 Add Override destination dialog to putaway location/quantity…

### DIFF
--- a/src/data/location/LocationType.ts
+++ b/src/data/location/LocationType.ts
@@ -3,6 +3,8 @@ import { LocationTypeCode } from './LocationTypeCode';
 interface LocationType {
   description?: string;
   locationTypeCode: LocationTypeCode;
+  name?: string;
+  id?: string;
 }
 
 export default LocationType;

--- a/src/redux/actions/locations.ts
+++ b/src/redux/actions/locations.ts
@@ -42,11 +42,7 @@ export function getBinLocationsAction(callback?: () => void) {
   };
 }
 
-export function setCurrentLocationAction(
-  location: any,
-  callback: (data: any) => void,
-  suppressLoading?: boolean
-) {
+export function setCurrentLocationAction(location: any, callback: (data: any) => void, suppressLoading?: boolean) {
   return {
     type: SET_CURRENT_LOCATION_REQUEST,
     payload: { location },

--- a/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
+++ b/src/screens/SortationPutaway/AlternativeLocationSelector.tsx
@@ -1,14 +1,27 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Alert, Modal, View } from 'react-native';
-import { Paragraph, Subheading } from 'react-native-paper';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Modal, ScrollView, TouchableOpacity, View } from 'react-native';
+import { Paragraph, RadioButton } from 'react-native-paper';
 import { useDispatch } from 'react-redux';
 
 import Button from '../../components/Button';
 import { ScannerInput } from '../../components/ScannerInput';
+import { SearchButton } from '../../components/SearchButton';
+import { useSearchButton } from '../../components/SearchButton/useSearchButton';
 import { appConfig, EMPTY_STRING } from '../../constants';
 import { getAlternativeDestinationsAction, searchLocationByLocationNumber } from '../../redux/actions/locations';
 import { SortationLocation, SortationTask } from '../../types/sortation';
+import Theme from '../../utils/Theme';
 import styles from './styles';
+
+const NEW_LOCATION_OPTION = '__new__';
+
+const buildDisplayList = (
+  current: SortationLocation | null | undefined,
+  alternatives: SortationLocation[]
+): SortationLocation[] => (current ? [current, ...alternatives.filter((loc) => loc.id !== current.id)] : alternatives);
+
+const getLocationSubtext = (location: SortationLocation): string | null =>
+  location?.locationType?.name ?? location?.locationType?.description ?? null;
 
 type Props = {
   visible: boolean;
@@ -28,50 +41,24 @@ export default function AlternativeLocationSelector({
   const dispatch = useDispatch();
 
   const [alternativeLocations, setAlternativeLocations] = useState<SortationLocation[]>([]);
-  const [tempAlternativeLocation, setTempAlternativeLocation] = useState<SortationLocation | null>(initialLocation);
-  const [scannedLocationInput, setScannedLocationInput] = useState('');
-  const [suggestionIndex, setSuggestionIndex] = useState(0);
-
-  // Reset state when modal opens
-  useEffect(() => {
-    if (visible) {
-      setTempAlternativeLocation(initialLocation);
-      setScannedLocationInput(EMPTY_STRING);
-      setSuggestionIndex(0);
-    }
-  }, [visible, initialLocation]);
-
-  // Load list of alternatives when modal opens
-  useEffect(() => {
-    if (!visible) {
-      return;
-    }
-
-    dispatch(
-      getAlternativeDestinationsAction(putawayDetails.facility.id, putawayDetails.id, (data: any) => {
-        if (data?.error) {
-          Alert.alert('Error', 'Failed to load alternative locations.');
-          return;
-        }
-        const mapped: SortationLocation[] = data.data.map((item: any) => ({
-          id: item.id,
-          name: item.name,
-          locationNumber: item.locationNumber
-        }));
-        setAlternativeLocations(mapped);
-      })
-    );
-  }, [dispatch, putawayDetails.facility.id, putawayDetails.id, visible]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [newLocationInput, setNewLocationInput] = useState<string>(EMPTY_STRING);
+  const [resolvedNewLocation, setResolvedNewLocation] = useState<SortationLocation | null>(null);
 
   const handleLocationSearch = useCallback(
     (locationNumber: string) => {
+      const trimmed = locationNumber?.trim();
+      if (!trimmed) {
+        setResolvedNewLocation(null);
+        return;
+      }
       dispatch(
-        searchLocationByLocationNumber(locationNumber, (data: any) => {
+        searchLocationByLocationNumber(trimmed, (data: any) => {
           if (data && !data.error) {
-            setTempAlternativeLocation(data);
+            setResolvedNewLocation(data);
           } else {
-            setTempAlternativeLocation(null);
-            Alert.alert('Location Not Found', `Location "${locationNumber}" could not be found.`);
+            setResolvedNewLocation(null);
+            Alert.alert('Location Not Found', `Location "${trimmed}" could not be found.`);
           }
         })
       );
@@ -79,30 +66,97 @@ export default function AlternativeLocationSelector({
     [dispatch]
   );
 
-  const handleSuggestLocation = () => {
-    if (alternativeLocations.length === 0) {
-      Alert.alert('No Suggestions', 'No alternative locations are available.');
+  const handleSearchSelect = useCallback(
+    (value: string) => {
+      setNewLocationInput(value);
+      handleLocationSearch(value);
+    },
+    [handleLocationSearch]
+  );
+
+  const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: handleSearchSelect });
+
+  const displayLocations = useMemo(
+    () => buildDisplayList(putawayDetails.destination, alternativeLocations),
+    [alternativeLocations, putawayDetails.destination]
+  );
+
+  useEffect(() => {
+    if (!visible) {
       return;
     }
-    const suggested = alternativeLocations[suggestionIndex];
-    setTempAlternativeLocation(suggested);
+    setNewLocationInput(EMPTY_STRING);
+    setResolvedNewLocation(null);
 
-    // Clear the manual input if they choose a suggestion
-    setScannedLocationInput(EMPTY_STRING);
+    const provisionalTarget = initialLocation ?? putawayDetails.destination;
+    setSelectedId(provisionalTarget?.id ?? null);
 
-    const nextIndex = (suggestionIndex + 1) % alternativeLocations.length;
-    setSuggestionIndex(nextIndex);
+    dispatch(
+      getAlternativeDestinationsAction(putawayDetails.facility.id, putawayDetails.id, (data: any) => {
+        if (data?.error) {
+          Alert.alert('Error', 'Failed to load alternative locations.');
+          return;
+        }
+        const items: any[] = Array.isArray(data?.data) ? data.data : [];
+        const mapped: SortationLocation[] = items.map((item: any) => ({
+          id: item.id,
+          name: item.name,
+          locationNumber: item.locationNumber,
+          locationType: item.locationType,
+          locationTypeCode: item.locationTypeCode,
+          zoneId: item.zoneId,
+          zoneName: item.zoneName,
+          active: item.active
+        }));
+        setAlternativeLocations(mapped);
+
+        const target = initialLocation ?? putawayDetails.destination;
+        if (!target) {
+          return;
+        }
+        const displayList = buildDisplayList(putawayDetails.destination, mapped);
+        if (displayList.some((loc) => loc.id === target.id)) {
+          setSelectedId(target.id);
+        } else {
+          setSelectedId(NEW_LOCATION_OPTION);
+          setNewLocationInput(target.locationNumber);
+          setResolvedNewLocation(target);
+        }
+      })
+    );
+  }, [dispatch, putawayDetails.facility.id, putawayDetails.id, putawayDetails.destination, visible, initialLocation]);
+
+  const handleSelectListed = (locationId: string) => {
+    setSelectedId(locationId);
+    setNewLocationInput(EMPTY_STRING);
+    setResolvedNewLocation(null);
   };
 
-  const handleConfirmAlternative = () => {
-    if (tempAlternativeLocation) {
-      onConfirm(tempAlternativeLocation);
+  const handleSelectNew = () => {
+    setSelectedId(NEW_LOCATION_OPTION);
+  };
+
+  const handleNewLocationInputChange = (value: string) => {
+    setNewLocationInput(value);
+    setResolvedNewLocation(null);
+  };
+
+  const isNewLocationMode = selectedId === NEW_LOCATION_OPTION;
+
+  const selectedLocation = isNewLocationMode
+    ? resolvedNewLocation
+    : displayLocations.find((loc) => loc.id === selectedId) ?? null;
+
+  // Disable Save until the selection actually differs from the current destination.
+  const isSaveEnabled = selectedLocation !== null && selectedLocation.id !== putawayDetails.destination?.id;
+
+  const handleSave = () => {
+    if (selectedLocation) {
+      onConfirm(selectedLocation);
+      onDismiss();
     }
-    onDismiss();
   };
 
-  // Don't render anything if not visible
-  // This ensures we do not fight for focus with the scanner input when the modal is closed
   if (!visible) {
     return null;
   }
@@ -111,38 +165,92 @@ export default function AlternativeLocationSelector({
     <Modal transparent visible={visible} animationType="slide" onRequestClose={onDismiss}>
       <View style={styles.modalOverlay}>
         <View style={styles.modalContent}>
-          <View style={styles.modalHeader}>
-            <Subheading style={styles.modalTitleText}>Choose Alternative Location</Subheading>
-          </View>
+          <Paragraph style={styles.dialogTitle}>Override destination</Paragraph>
 
-          <Paragraph style={styles.dialogCurrentLocationWrapper}>
-            <Paragraph style={styles.dialogCurrentLocationLabel}>Current Location: </Paragraph>
-            {putawayDetails.destination?.name || 'Unassigned'}
-          </Paragraph>
+          <ScrollView style={styles.locationList} keyboardShouldPersistTaps="always">
+            {displayLocations.map((location) => {
+              const isSelected = selectedId === location.id;
+              const subtext = getLocationSubtext(location);
+              return (
+                <TouchableOpacity
+                  key={location.id}
+                  style={[styles.locationRow, isSelected && styles.locationRowSelected]}
+                  onPress={() => handleSelectListed(location.id)}
+                >
+                  <RadioButton
+                    value={location.id}
+                    status={isSelected ? 'checked' : 'unchecked'}
+                    color={Theme.colors.primary}
+                    onPress={() => handleSelectListed(location.id)}
+                  />
+                  <View style={styles.locationRowContent}>
+                    <View>
+                      <Paragraph style={styles.locationRowName}>{location.name}</Paragraph>
+                      {subtext ? <Paragraph style={styles.locationRowSubtext}>{subtext}</Paragraph> : null}
+                    </View>
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
 
-          <Button
-            size="100%"
-            title="Suggest new location"
-            mode="contained"
-            style={styles.dialogSuggestButton}
-            onPress={handleSuggestLocation}
-          />
+            <TouchableOpacity
+              style={[
+                styles.useNewLocationRow,
+                styles.locationRowLast,
+                isNewLocationMode && styles.locationRowSelected
+              ]}
+              onPress={handleSelectNew}
+            >
+              <RadioButton
+                value={NEW_LOCATION_OPTION}
+                status={isNewLocationMode ? 'checked' : 'unchecked'}
+                color={Theme.colors.primary}
+                onPress={handleSelectNew}
+              />
+              <View style={styles.locationRowContent}>
+                <Paragraph style={styles.locationRowName}>Use a new location</Paragraph>
+              </View>
+            </TouchableOpacity>
+          </ScrollView>
 
-          <ScannerInput
-            label="Scan location number"
-            autoSubmitTimeout={appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME}
-            value={scannedLocationInput}
-            onChange={setScannedLocationInput}
-            onSubmit={handleLocationSearch}
-          />
+          {isNewLocationMode && (
+            <View style={styles.destinationInputContainer}>
+              <View style={styles.scannerRow}>
+                <ScannerInput
+                  style={styles.scannerInput}
+                  label="Destination"
+                  placeholder="Scan or type the new ID"
+                  value={newLocationInput}
+                  isEnabled={!isSearchOpen}
+                  autoSubmitTimeout={appConfig.DEFAULT_SEARCH_DEBOUNCE_TIME}
+                  onChange={handleNewLocationInputChange}
+                  onSubmit={handleLocationSearch}
+                />
+                <SearchButton searchType="location" {...searchButtonProps} />
+              </View>
+            </View>
+          )}
 
-          <Paragraph style={styles.dialogNewLocationHeader}>
-            New Location: {tempAlternativeLocation?.name || 'Unknown'}
-          </Paragraph>
-
-          <View style={styles.dialogActions}>
-            <Button size="default" mode="text" title="Cancel" onPress={onDismiss} />
-            <Button size="default" title="Confirm" onPress={handleConfirmAlternative} />
+          <View style={styles.dialogActionsRow}>
+            <Button
+              icon="close-circle"
+              size="default"
+              variant="secondary"
+              style={styles.dialogActionButton}
+              title="Cancel"
+              mode="contained"
+              onPress={onDismiss}
+            />
+            <View style={styles.dialogActionSpacer} />
+            <Button
+              icon="check-circle"
+              size="default"
+              style={styles.dialogActionButton}
+              title="Save"
+              mode="contained"
+              disabled={!isSaveEnabled}
+              onPress={handleSave}
+            />
           </View>
         </View>
       </View>

--- a/src/screens/SortationPutaway/PutawayDetails.tsx
+++ b/src/screens/SortationPutaway/PutawayDetails.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Text, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { Chip, Divider, Title } from 'react-native-paper';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { EMPTY_FALLBACK } from '../../constants';
-import { DetailChip, SortationTask } from '../../types/sortation';
+import { SortationTask } from '../../types/sortation';
+import Theme from '../../utils/Theme';
 import styles from './styles';
 
 type PutawayDetailsProps = {
@@ -11,37 +13,22 @@ type PutawayDetailsProps = {
   taskIndex?: number;
   totalTasks?: number;
   showTaskCounter?: boolean;
+  onOverrideDestination?: () => void;
 };
 
 export default function PutawayDetails({
   putawayDetails,
   taskIndex,
   totalTasks,
-  showTaskCounter = true
+  showTaskCounter = true,
+  onOverrideDestination
 }: PutawayDetailsProps) {
   if (!putawayDetails) {
     return null;
   }
 
   const { inventoryItem, quantity, container, destination } = putawayDetails;
-
-  const detailsChips: DetailChip[] = [
-    {
-      icon: 'identifier',
-      label: 'Putaway Container ID',
-      value: container?.locationNumber ?? EMPTY_FALLBACK
-    },
-    {
-      icon: 'map-marker',
-      label: 'Putaway Location',
-      value: destination?.name ?? EMPTY_FALLBACK
-    },
-    {
-      icon: 'cube',
-      label: 'Putaway Quantity',
-      value: quantity ?? EMPTY_FALLBACK
-    }
-  ];
+  const destinationName = destination?.name ?? EMPTY_FALLBACK;
 
   return (
     <View style={styles.productDetails}>
@@ -65,13 +52,40 @@ export default function PutawayDetails({
 
       <Title style={styles.title}>{inventoryItem?.product?.name}</Title>
 
-      {detailsChips.map(({ icon, value, label }) => (
-        <Chip key={label} icon={icon} style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
+      <Chip icon="identifier" style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
+        <Text>
+          Putaway Container ID: <Text style={styles.bold}>{container?.locationNumber ?? EMPTY_FALLBACK}</Text>
+        </Text>
+      </Chip>
+
+      {onOverrideDestination ? (
+        <View style={[styles.chipDestination, styles.topSpace]}>
+          <MaterialCommunityIcons
+            name="map-marker"
+            size={16}
+            color={Theme.colors.text}
+            style={styles.chipDestinationIcon}
+          />
+          <Text style={[styles.chipText, styles.chipDestinationLabel]} numberOfLines={1}>
+            Putaway Location: <Text style={styles.bold}>{destinationName}</Text>
+          </Text>
+          <TouchableOpacity hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }} onPress={onOverrideDestination}>
+            <Text style={styles.overrideLink}>Override</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <Chip icon="map-marker" style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
           <Text>
-            {label}: <Text style={styles.bold}>{value}</Text>
+            Putaway Location: <Text style={styles.bold}>{destinationName}</Text>
           </Text>
         </Chip>
-      ))}
+      )}
+
+      <Chip icon="cube" style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
+        <Text>
+          Putaway Quantity: <Text style={styles.bold}>{quantity ?? EMPTY_FALLBACK}</Text>
+        </Text>
+      </Chip>
     </View>
   );
 }

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -1,7 +1,7 @@
 import { RouteProp, useRoute } from '@react-navigation/native';
 import React, { useEffect, useState } from 'react';
 import { Alert, ScrollView, View } from 'react-native';
-import { Divider, Paragraph, Subheading } from 'react-native-paper';
+import { Divider, Subheading } from 'react-native-paper';
 import { useSelector } from 'react-redux';
 
 import Button from '../../components/Button';
@@ -101,6 +101,7 @@ export default function PutawayLocationScanScreen() {
           taskIndex={currentTaskIndex}
           totalTasks={putawayTasks?.length || 0}
           showTaskCounter={!isUserDirected}
+          onOverrideDestination={() => setIsDialogVisible(true)}
         />
 
         <Divider />
@@ -118,13 +119,6 @@ export default function PutawayLocationScanScreen() {
               onSubmit={handleProcessing}
             />
             <SearchButton searchType="location" {...searchButtonProps} />
-          </View>
-
-          <View style={styles.topSpace}>
-            <View style={[styles.headerRow, styles.bottomSpace]}>
-              <Paragraph style={styles.subheading}>Alternative Location?</Paragraph>
-              <Button size="50%" title="Request" onPress={() => setIsDialogVisible(true)} />
-            </View>
           </View>
 
           <Button

--- a/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayQuantityScreen.tsx
@@ -251,6 +251,7 @@ export default function PutawayQuantityScreen() {
           taskIndex={currentTaskIndex}
           totalTasks={putawayTasks?.length || 0}
           showTaskCounter={!isUserDirected}
+          onOverrideDestination={() => setIsDialogVisible(true)}
         />
         <Divider />
 
@@ -268,29 +269,22 @@ export default function PutawayQuantityScreen() {
             onSubmit={handleConfirm}
           />
 
-          <View style={styles.topSpace}>
-            <View style={[styles.headerRow, styles.bottomSpace]}>
-              <Paragraph style={styles.subheading}>Alternative Location?</Paragraph>
-              <Button size="50%" title="Request" onPress={() => setIsDialogVisible(true)} />
-            </View>
-
-            {hasDiscrepancy && (
-              <View style={styles.headerRow}>
-                <Paragraph style={styles.subheading}>Discrepancy Reason</Paragraph>
-                <View style={styles.dropdownContainer}>
-                  <AsyncModalSelect
-                    placeholder="Select a reason"
-                    label="Reason for shortage"
-                    initValue={selectedReasonCode?.name || ''}
-                    initialData={reasonCodes}
-                    searchAction={() => {}}
-                    serverSearchEnabled={false}
-                    onSelect={(reason: ReasonCode) => setSelectedReasonCode(reason)}
-                  />
-                </View>
+          {hasDiscrepancy && (
+            <View style={[styles.topSpace, styles.headerRow]}>
+              <Paragraph style={styles.subheading}>Discrepancy Reason</Paragraph>
+              <View style={styles.dropdownContainer}>
+                <AsyncModalSelect
+                  placeholder="Select a reason"
+                  label="Reason for shortage"
+                  initValue={selectedReasonCode?.name || ''}
+                  initialData={reasonCodes}
+                  searchAction={() => {}}
+                  serverSearchEnabled={false}
+                  onSelect={(reason: ReasonCode) => setSelectedReasonCode(reason)}
+                />
               </View>
-            )}
-          </View>
+            </View>
+          )}
 
           <View style={styles.cardAnnotation}>
             <Paragraph style={[styles.subheading, isCancelRemainingDisabled && styles.subheadingDisabled]}>

--- a/src/screens/SortationPutaway/styles.ts
+++ b/src/screens/SortationPutaway/styles.ts
@@ -132,19 +132,92 @@ export default StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'flex-end'
   },
-  dialogNewLocationHeader: {
-    marginBottom: Theme.spacing.large,
-    marginTop: Theme.spacing.small,
-    fontWeight: 'bold',
-    fontSize: 16
+  dialogActionsRow: {
+    flexDirection: 'row',
+    alignItems: 'center'
   },
-  dialogCurrentLocationLabel: {
-    fontWeight: 'bold',
-    fontSize: 16
+  dialogActionButton: {
+    flex: 1
   },
-  dialogCurrentLocationWrapper: {
-    marginBottom: 16,
-    fontWeight: 'bold'
+  dialogActionSpacer: {
+    width: Theme.spacing.small
+  },
+  dialogTitle: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: Theme.colors.text,
+    marginBottom: Theme.spacing.large
+  },
+  chipDestination: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    backgroundColor: '#ebebeb',
+    borderRadius: 4,
+    minHeight: 28
+  },
+  chipDestinationIcon: {
+    marginRight: 6
+  },
+  chipDestinationLabel: {
+    flex: 1
+  },
+  overrideLink: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Theme.colors.primary,
+    textDecorationLine: 'underline',
+    paddingHorizontal: 4
+  },
+  locationList: {
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+    borderRadius: Theme.roundness * 2,
+    overflow: 'hidden',
+    marginBottom: Theme.spacing.large
+  },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Theme.spacing.medium,
+    paddingHorizontal: Theme.spacing.medium,
+    backgroundColor: 'white',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E0E0E0'
+  },
+  locationRowLast: {
+    borderBottomWidth: 0
+  },
+  locationRowSelected: {
+    backgroundColor: '#E8F0FE'
+  },
+  locationRowContent: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginLeft: Theme.spacing.small
+  },
+  locationRowName: {
+    fontSize: 15,
+    fontWeight: 'bold',
+    color: Theme.colors.text
+  },
+  locationRowSubtext: {
+    fontSize: 13,
+    color: Theme.colors.disabled,
+    marginTop: 2
+  },
+  useNewLocationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: Theme.spacing.medium,
+    paddingHorizontal: Theme.spacing.medium,
+    backgroundColor: 'white'
+  },
+  destinationInputContainer: {
+    marginBottom: Theme.spacing.large
   },
   modalSurface: {
     width: '90%',
@@ -176,13 +249,6 @@ export default StyleSheet.create({
     fontWeight: 'bold',
     color: Theme.colors.text,
     flexShrink: 1
-  },
-  dialogSuggestButton: {
-    marginBottom: Theme.spacing.large,
-    marginTop: Theme.spacing.medium
-  },
-  dialogActionButton: {
-    marginLeft: Theme.spacing.small
   },
   modeCardContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
… screen

https://openboxes.atlassian.net/browse/OBLS-558

  ## What changed
 - Replaced the big **Request** button + "Alternative Location?" row with an inline **Override** link inside the Putaway Location chip (Location Scan + Quantity screens).
 - Redesigned the dialog into **Override destination**:
    - Selectable list - current destination first, then deduped alternatives (name + type).
    - **Use a new location** option with a scan/search Destination field.
    - Current destination preselected; **Save** disabled until the selection changes.


https://github.com/user-attachments/assets/36fa41be-43d7-4e14-8f7f-5c676a0f55e7

