### PR TITLE
OBLS-778 Set vvg as a default profile if no active is set

### DIFF
--- a/src/components/ProfileStorage.ts
+++ b/src/components/ProfileStorage.ts
@@ -11,9 +11,10 @@ const PROFILES_KEY = 'PROFILES';
 const LEGACY_API_URL_KEY = 'API_URL';
 const CURRENT_VERSION = 1;
 
+// The first one in the list will be used as the default active profile if no activeProfileId is set
 const DEFAULT_SERVERS = [
-  { label: 'Staging Server', serverUrl: 'https://stag.vtc.openboxes.com/openboxes/api' },
-  { label: 'Test Server', serverUrl: 'https://vvg.openboxes.com/openboxes/api' }
+  { label: 'Test Server', serverUrl: 'https://vvg.openboxes.com/openboxes/api' },
+  { label: 'Staging Server', serverUrl: 'https://stag.vtc.openboxes.com/openboxes/api' }
 ];
 
 const emitter = createEventEmitter();


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-778

Changes:
- If no active profile, the `migrate()` function is using the first item from the `DEFAULT_SERVERS` list as a default. Use `vvg.openboxes.com` as a default if no active (instead of `stag.vtc.openboxes.com`).