### PR TITLE
OBLS-800 Remove unnecessary duplicate product scan in sorted putaway

### DIFF
--- a/src/screens/Sortation/SortationQuantityScreen.tsx
+++ b/src/screens/Sortation/SortationQuantityScreen.tsx
@@ -38,7 +38,8 @@ export default function SortationQuantityScreen() {
         currentTaskIndex: 0,
         isDirectPutaway: true,
         isUserDirected: true,
-        task
+        task,
+        requiresValidationScan: false
       });
     }
   }, [directPutawayRequired, product, task]);

--- a/src/screens/SortationPutaway/PutawayDetails.tsx
+++ b/src/screens/SortationPutaway/PutawayDetails.tsx
@@ -67,7 +67,7 @@ export default function PutawayDetails({
             style={styles.chipDestinationIcon}
           />
           <Text style={[styles.chipText, styles.chipDestinationLabel]} numberOfLines={1}>
-            Putaway Location: <Text style={styles.bold}>{destinationName}</Text>
+            Destination: <Text style={styles.bold}>{destinationName}</Text>
           </Text>
           <TouchableOpacity hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }} onPress={onOverrideDestination}>
             <Text style={styles.overrideLink}>Override</Text>
@@ -76,7 +76,7 @@ export default function PutawayDetails({
       ) : (
         <Chip icon="map-marker" style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
           <Text>
-            Putaway Location: <Text style={styles.bold}>{destinationName}</Text>
+            Destination: <Text style={styles.bold}>{destinationName}</Text>
           </Text>
         </Chip>
       )}

--- a/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayLocationScanScreen.tsx
@@ -26,6 +26,7 @@ type PutawayLocationScanRouteProp = RouteProp<
       isUserDirected?: boolean;
       containerId?: string;
       task?: SortationTask;
+      requiresValidationScan?: boolean;
     };
   },
   'SortationPutawayLocationScan'
@@ -33,7 +34,8 @@ type PutawayLocationScanRouteProp = RouteProp<
 
 export default function PutawayLocationScanScreen() {
   const { params } = useRoute<PutawayLocationScanRouteProp>();
-  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task } = params;
+  const { currentTaskIndex, isDirectPutaway, isUserDirected, containerId, task, requiresValidationScan } = params;
+  const shouldValidateProduct = requiresValidationScan ?? true;
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
   const putawayDetails = task ?? putawayTasks?.[currentTaskIndex];
 
@@ -80,7 +82,7 @@ export default function PutawayLocationScanScreen() {
       return;
     }
 
-    navigate('SortationPutawayProductScan', {
+    navigate(shouldValidateProduct ? 'SortationPutawayProductScan' : 'SortationPutawayQuantity', {
       currentTaskIndex,
       isDirectPutaway,
       isUserDirected,
@@ -107,12 +109,12 @@ export default function PutawayLocationScanScreen() {
         <Divider />
 
         <View style={styles.formContainer}>
-          <Subheading style={styles.subheading}>Scan putaway location or use search to find it</Subheading>
+          <Subheading style={styles.subheading}>Scan destination or use search to find it</Subheading>
 
           <View style={styles.scannerRow}>
             <ScannerInput
               style={styles.scannerInput}
-              label="Putaway Location Entry Field"
+              label="Destination Entry Field"
               value={putawayLocationBarcode}
               isEnabled={!isDialogVisible && !isSearchOpen}
               onChange={setPutawayLocationBarcode}

--- a/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
+++ b/src/screens/SortationPutaway/PutawayTaskListScreen.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import React, { useCallback, useMemo, useState } from 'react';
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, ScrollView, Text, TouchableOpacity, View } from 'react-native';
 import { Button, Chip, Divider, Paragraph } from 'react-native-paper';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -12,6 +12,7 @@ import { useSearchButton } from '../../components/SearchButton/useSearchButton';
 import { getPutawayDetailsByContainerId } from '../../redux/actions/putaways';
 import { RootState } from '../../redux/reducers';
 import { SortationTask } from '../../types/sortation';
+import { isProductBarcodeValid } from '../../utils/utils';
 import styles from './styles';
 
 type RootStackParamList = {
@@ -19,6 +20,7 @@ type RootStackParamList = {
     currentTaskIndex: number;
     isUserDirected?: boolean;
     containerId?: string;
+    requiresValidationScan?: boolean;
   };
   SortationPutawayTaskList: {
     containerId: string;
@@ -94,7 +96,59 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
   const putawayTasks = useSelector((state: RootState) => state.putawayReducer.putawayTasks) as SortationTask[];
   const [searchTerm, setSearchTerm] = useState('');
   const [expandedZones, setExpandedZones] = useState<{ [key: string]: boolean }>({});
-  const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: setSearchTerm });
+  const [enteredManually, setEnteredManually] = useState(true);
+
+  const resetFilters = () => {
+    setSearchTerm('');
+    setEnteredManually(true);
+  };
+
+  const navigateToTask = (task: SortationTask, requiresValidationScan: boolean) => {
+    const globalIndex = putawayTasks.findIndex((t) => t.id === task.id);
+    resetFilters();
+    navigation.navigate('SortationPutawayLocationScan', {
+      currentTaskIndex: globalIndex >= 0 ? globalIndex : 0,
+      isUserDirected: true,
+      containerId,
+      requiresValidationScan
+    });
+  };
+
+  const handleScanChange = (text: string) => {
+    setSearchTerm(text);
+    setEnteredManually(false);
+  };
+
+  const handleScan = (code: string) => {
+    const trimmed = code.trim();
+    if (!trimmed) {
+      return;
+    }
+    const matches = (putawayTasks ?? []).filter((task) => isProductBarcodeValid(trimmed, task.inventoryItem?.product));
+
+    if (matches.length === 1) {
+      navigateToTask(matches[0], enteredManually);
+      return;
+    }
+    if (matches.length > 1) {
+      setSearchTerm(matches[0].inventoryItem?.product?.productCode ?? trimmed);
+      return;
+    }
+
+    Alert.alert('No Matching Task', 'No putaway task was found for the scanned product.');
+  };
+
+  const handleSearchSelect = (productCode: string) => {
+    const matches = (putawayTasks ?? []).filter((task) => task.inventoryItem?.product?.productCode === productCode);
+    setEnteredManually(true);
+    if (matches.length === 1) {
+      navigateToTask(matches[0], true);
+    } else {
+      setSearchTerm(productCode);
+    }
+  };
+
+  const { isSearchOpen, searchButtonProps } = useSearchButton({ onSelect: handleSearchSelect });
 
   const fetchTasks = useCallback(() => {
     dispatch(getPutawayDetailsByContainerId(containerId));
@@ -163,19 +217,12 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
     }
 
     const selectedTask = zoneTasks.tasks[taskIndex];
-    const globalIndex = putawayTasks.findIndex((t) => t.id === selectedTask.id);
 
-    setSearchTerm('');
-
-    navigation.navigate('SortationPutawayLocationScan', {
-      currentTaskIndex: globalIndex >= 0 ? globalIndex : 0,
-      isUserDirected: true,
-      containerId
-    });
+    navigateToTask(selectedTask, enteredManually);
   };
 
   const handleClearSearch = () => {
-    setSearchTerm('');
+    resetFilters();
   };
 
   return (
@@ -196,8 +243,8 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
             label="Product"
             style={styles.scannerInput}
             isEnabled={!isSearchOpen}
-            onChange={setSearchTerm}
-            onSubmit={setSearchTerm}
+            onChange={handleScanChange}
+            onSubmit={handleScan}
           />
           <SearchButton searchType="product" {...searchButtonProps} />
         </View>
@@ -213,7 +260,7 @@ export default function PutawayTaskListScreen({ route }: PutawayTaskListScreenPr
       <View style={styles.formContainer}>
         <View style={styles.tableHeader}>
           <Text style={[styles.tableHeaderText, styles.tableHeaderProduct]}>Product</Text>
-          <Text style={[styles.tableHeaderText, styles.tableHeaderLocation]}>Putaway Location</Text>
+          <Text style={[styles.tableHeaderText, styles.tableHeaderLocation]}>Destination</Text>
           <Text style={[styles.tableHeaderText, styles.tableHeaderQty]}>Quantity</Text>
         </View>
         {groupedTasks.length === 0 ? (


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-800

## Changes
- `PutawayLocationScanScreen`: after the destination scan, skip the product scan and go straight to quantity unless a validation scan is required (new requiresValidationScan param, defaults to true).
- `PutawayTaskListScreen`: a product scan or search that resolves to a single task goes straight to the details screen. Scanning into the barcode field is treated as scanned (no validation scan); using the search dialog or a plain task selection requires it. Single search/filter state plus an `enteredManually` flag;
- `SortationQuantityScreen`: direct putaway from sortation skips the validation scan, since the product was already scanned at sortation.
- System-directed putaway always requires the validation scan.
- Rename the "Putaway Location" label to "Destination" across the sorted putaway screens.