### PR TITLE
OBLS-814 Show product code as primary heading on product-centric screens

### DIFF
--- a/src/components/ProductDetails/index.tsx
+++ b/src/components/ProductDetails/index.tsx
@@ -63,7 +63,12 @@ function Badge({ icon, label, children }: { icon?: string; label?: string; child
 
 function Title() {
   const { product } = useProduct();
-  return <PaperTitle style={styles.title}>{product.name}</PaperTitle>;
+  return (
+    <>
+      <PaperTitle style={styles.title}>{product.productCode}</PaperTitle>
+      <PaperCaption style={styles.caption}>{product.name}</PaperCaption>
+    </>
+  );
 }
 
 function Caption({ title, subtitle }: { title?: string; subtitle?: string }) {

--- a/src/screens/Picking/PickingPickLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickLocationScreen.tsx
@@ -71,9 +71,6 @@ export default function PickingPickLocationScreen() {
       <ProductDetails.Provider product={currentTask.product} status={currentTask.status}>
         <ProductDetails.Root>
           <ProductDetails.Header>
-            <ProductDetails.Badge icon="barcode" label="Product Code">
-              {currentTask.product.productCode}
-            </ProductDetails.Badge>
             <ProductDetails.Badge icon="navigation" label="Pick Task">
               {`${currentTaskIndex + 1} / ${allTasksCount || 0}`}
             </ProductDetails.Badge>

--- a/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
+++ b/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
@@ -103,9 +103,6 @@ export default function PickingPickOutboundContainerScreen() {
       <ProductDetails.Provider product={currentTask.product} status={currentTask.status}>
         <ProductDetails.Root>
           <ProductDetails.Header>
-            <ProductDetails.Badge icon="barcode" label="Product Code">
-              {currentTask.product.productCode}
-            </ProductDetails.Badge>
             <ProductDetails.Badge icon="navigation" label="Pick Task">
               {`${currentTaskIndex + 1} / ${allTasksCount}`}
             </ProductDetails.Badge>

--- a/src/screens/Picking/PickingPickProductScreen.tsx
+++ b/src/screens/Picking/PickingPickProductScreen.tsx
@@ -43,9 +43,6 @@ export default function PickingPickProductScreen() {
       <ProductDetails.Provider product={currentTask.product} status={currentTask.status}>
         <ProductDetails.Root>
           <ProductDetails.Header>
-            <ProductDetails.Badge icon="barcode" label="Product Code">
-              {currentTask.product.productCode}
-            </ProductDetails.Badge>
             <ProductDetails.Badge icon="navigation" label="Pick Task">
               {`${currentTaskIndex + 1} / ${allTasksCount}`}
             </ProductDetails.Badge>

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -115,9 +115,6 @@ export default function PickingPickQuantityScreen() {
         <ProductDetails.Provider product={currentTask.product} status={currentTask.status}>
           <ProductDetails.Root>
             <ProductDetails.Header>
-              <ProductDetails.Badge icon="barcode" label="Product Code">
-                {currentTask.product.productCode}
-              </ProductDetails.Badge>
               <ProductDetails.Badge icon="navigation" label="Pick Task">
                 {`${currentTaskIndex + 1} / ${allTasksCount}`}
               </ProductDetails.Badge>

--- a/src/screens/Picking/PickingPickStagingLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickStagingLocationScreen.tsx
@@ -90,9 +90,6 @@ export default function PickingPickStagingLocationScreen() {
       <ProductDetails.Provider product={currentTask.product} status={currentTask.status}>
         <ProductDetails.Root>
           <ProductDetails.Header>
-            <ProductDetails.Badge icon="barcode" label="Product Code">
-              {currentTask.product.productCode}
-            </ProductDetails.Badge>
             <ProductDetails.Badge icon="navigation" label="Task Progress">
               {`${currentUniqueIndex + 1} / ${uniqueTasks.length}`}
             </ProductDetails.Badge>

--- a/src/screens/ProductDetails/index.tsx
+++ b/src/screens/ProductDetails/index.tsx
@@ -245,15 +245,8 @@ class ProductDetails extends React.Component<Props, State> {
               </>
             )}
 
-            <View style={styles.headerRow}>
-              <Chip icon="barcode" style={styles.chipDefault} textStyle={styles.chipText}>
-                {vm.productCode || HYPHEN}
-              </Chip>
-            </View>
-
-            <Divider style={styles.contentDivider} />
-
-            <Title style={styles.title}>{vm.name}</Title>
+            <Title style={styles.title}>{vm.productCode || HYPHEN}</Title>
+            <Caption style={styles.subtitle}>{vm.name}</Caption>
             <Caption style={styles.subtitle}>{`Barcode: ${vm.upc}`}</Caption>
 
             <View style={styles.actionButtons}>

--- a/src/screens/Sortation/SortationProductDetails.tsx
+++ b/src/screens/Sortation/SortationProductDetails.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Chip, Divider, Paragraph, Switch, Text, Title } from 'react-native-paper';
+import { Caption, Chip, Divider, Paragraph, Switch, Text, Title } from 'react-native-paper';
 
-import { ProductIcon } from '../../components/Icons';
 import { EMPTY_FALLBACK } from '../../constants';
 import { DetailChip, SortationProduct, SortationTask } from '../../types/sortation';
 import Theme from '../../utils/Theme';
@@ -28,21 +27,12 @@ export default function SortationProductDetails({
 
   return (
     <View style={styles.productDetails}>
-      <View style={styles.headerRow}>
-        <Chip
-          icon={() => <ProductIcon size={16} color="#000" />}
-          style={styles.chipDefault}
-          textStyle={styles.chipText}
-        >
-          {productCode}
-        </Chip>
-      </View>
-
-      <Divider style={styles.contentDivider} />
-
-      <Title style={styles.title}>{name}</Title>
+      <Title style={styles.title}>{productCode}</Title>
+      <Caption style={styles.caption}>{name}</Caption>
 
       {product.description ? <Paragraph style={[styles.paragraphMuted]}>{product.description}</Paragraph> : null}
+
+      <Divider style={styles.contentDivider} />
 
       {detailsChips.map(({ icon, value, label, isActive }) => (
         <Chip key={label} icon={icon} style={[styles.chipDefault, styles.topSpace, isActive && styles.chipActive]}>

--- a/src/screens/Sortation/styles.ts
+++ b/src/screens/Sortation/styles.ts
@@ -62,7 +62,7 @@ export default StyleSheet.create({
   title: {
     fontSize: 18,
     color: Theme.colors.text,
-    fontWeight: '600'
+    fontWeight: 'bold'
   },
   subheading: {
     fontSize: 16,

--- a/src/screens/SortationPutaway/PutawayDetails.tsx
+++ b/src/screens/SortationPutaway/PutawayDetails.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
-import { Chip, Divider, Title } from 'react-native-paper';
+import { Caption, Chip, Divider, Title } from 'react-native-paper';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 
 import { EMPTY_FALLBACK } from '../../constants';
@@ -32,25 +32,23 @@ export default function PutawayDetails({
 
   return (
     <View style={styles.productDetails}>
-      <View style={styles.headerRow}>
-        <Chip icon="barcode" style={styles.chipDefault} textStyle={styles.chipText}>
-          <Text>
-            Product Code: <Text style={styles.bold}>{inventoryItem?.product?.productCode}</Text>
-          </Text>
-        </Chip>
-        {showTaskCounter && taskIndex !== undefined && totalTasks !== undefined && (
-          <Chip icon="navigation" style={styles.chipDefault} textStyle={styles.chipText}>
-            Tasks:{' '}
-            <Text style={styles.bold}>
-              {taskIndex + 1} / {totalTasks}
-            </Text>
-          </Chip>
-        )}
-      </View>
+      {showTaskCounter && taskIndex !== undefined && totalTasks !== undefined && (
+        <>
+          <View style={styles.headerRow}>
+            <Chip icon="navigation" style={styles.chipDefault} textStyle={styles.chipText}>
+              Tasks:{' '}
+              <Text style={styles.bold}>
+                {taskIndex + 1} / {totalTasks}
+              </Text>
+            </Chip>
+          </View>
 
-      <Divider style={styles.contentDivider} />
+          <Divider style={styles.contentDivider} />
+        </>
+      )}
 
-      <Title style={styles.title}>{inventoryItem?.product?.name}</Title>
+      <Title style={styles.title}>{inventoryItem?.product?.productCode}</Title>
+      <Caption style={styles.caption}>{inventoryItem?.product?.name}</Caption>
 
       <Chip icon="identifier" style={[styles.chipDefault, styles.topSpace]} textStyle={styles.chipText}>
         <Text>


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-814

## Changes
- Operators reference products by part number far more than by descriptive name, so the part number (productCode) is now the primary heading and the product name is the secondary line beneath it, across the product-centric screens.