### PR TITLE
OBLS-566 Replace Direct Putaway Required toggle with Putaway Method tabs

### DIFF
--- a/src/components/SegmentedControl/index.tsx
+++ b/src/components/SegmentedControl/index.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { StyleProp, TouchableOpacity, View, ViewStyle } from 'react-native';
+import { Text } from 'react-native-paper';
+import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
+
+import Theme from '../../utils/Theme';
+import styles from './styles';
+
+export type SegmentedOption<T extends string> = {
+  value: T;
+  label: string;
+  icon?: string;
+};
+
+type SegmentedControlProps<T extends string> = {
+  options: SegmentedOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  style?: StyleProp<ViewStyle>;
+};
+
+export function SegmentedControl<T extends string>({ options, value, onChange, style }: SegmentedControlProps<T>) {
+  return (
+    <View style={[styles.container, style]}>
+      {options.map((option) => {
+        const selected = option.value === value;
+        return (
+          <TouchableOpacity
+            key={option.value}
+            activeOpacity={0.7}
+            style={[styles.segment, selected && styles.segmentSelected]}
+            onPress={() => onChange(option.value)}
+          >
+            {option.icon ? (
+              <MaterialCommunityIcons
+                name={option.icon}
+                size={18}
+                color={selected ? Theme.colors.primary : Theme.colors.disabled}
+                style={styles.segmentIcon}
+              />
+            ) : null}
+            <Text style={[styles.segmentText, selected && styles.segmentTextSelected]}>{option.label}</Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
+  );
+}

--- a/src/components/SegmentedControl/styles.ts
+++ b/src/components/SegmentedControl/styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from 'react-native';
+
+import Theme from '../../utils/Theme';
+
+export default StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    backgroundColor: Theme.colors.secondaryBackground,
+    borderRadius: 8,
+    padding: 4
+  },
+  segment: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 10,
+    borderRadius: 6
+  },
+  segmentSelected: {
+    backgroundColor: '#FFFFFF'
+  },
+  segmentIcon: {
+    marginRight: 6
+  },
+  segmentText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Theme.colors.disabled
+  },
+  segmentTextSelected: {
+    color: Theme.colors.primary,
+    fontWeight: 'bold'
+  }
+});

--- a/src/screens/Sortation/SortationProductDetails.tsx
+++ b/src/screens/Sortation/SortationProductDetails.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { View } from 'react-native';
-import { Caption, Chip, Divider, Paragraph, Switch, Text, Title } from 'react-native-paper';
+import { Caption, Chip, Divider, Paragraph, Text, Title } from 'react-native-paper';
 
+import ArrowRight from '../../assets/images/arrow_right.svg';
+import { SegmentedControl, SegmentedOption } from '../../components/SegmentedControl';
 import { EMPTY_FALLBACK } from '../../constants';
 import { DetailChip, SortationProduct, SortationTask } from '../../types/sortation';
 import Theme from '../../utils/Theme';
@@ -15,6 +17,44 @@ export type SortationProductDetailsProps = {
   task?: SortationTask;
   onToggleDirectPutaway?: (value: boolean) => void;
 };
+
+type PutawayMethod = 'SORTED' | 'DIRECT';
+
+const PUTAWAY_METHOD_HINTS: Record<PutawayMethod, string> = {
+  SORTED: 'Sort to a temporary putaway container — scan a container next.',
+  DIRECT: 'Put the item away directly to its storage location now.'
+};
+
+const PUTAWAY_METHOD_OPTIONS: SegmentedOption<PutawayMethod>[] = [
+  { value: 'SORTED', label: 'Sorted', icon: 'package-variant-closed' },
+  { value: 'DIRECT', label: 'Direct', icon: 'map-marker-radius' }
+];
+
+function PutawayMethodSelector({
+  value,
+  onChange
+}: {
+  value: PutawayMethod;
+  onChange: (method: PutawayMethod) => void;
+}) {
+  return (
+    <View>
+      <Paragraph style={[styles.paragraph, styles.bold]}>Putaway Method</Paragraph>
+
+      <SegmentedControl
+        style={styles.methodSelector}
+        options={PUTAWAY_METHOD_OPTIONS}
+        value={value}
+        onChange={onChange}
+      />
+
+      <View style={styles.methodHintRow}>
+        <ArrowRight width={16} height={16} fill={Theme.colors.secondaryForeground} style={styles.methodHintIcon} />
+        <Text style={styles.methodHint}>{PUTAWAY_METHOD_HINTS[value]}</Text>
+      </View>
+    </View>
+  );
+}
 
 export default function SortationProductDetails({
   product,
@@ -60,15 +100,10 @@ export default function SortationProductDetails({
       {showDirectPutawayRequired && (
         <>
           <Divider style={styles.contentDivider} />
-          <View style={styles.cardAnnotation}>
-            <Paragraph style={[styles.paragraph, styles.bold]}>Direct Putaway Required</Paragraph>
-            <Switch
-              disabled={!onToggleDirectPutaway}
-              color={Theme.colors.primary}
-              value={directPutawayRequired}
-              onValueChange={(val) => onToggleDirectPutaway?.(val)}
-            />
-          </View>
+          <PutawayMethodSelector
+            value={directPutawayRequired ? 'DIRECT' : 'SORTED'}
+            onChange={(method) => onToggleDirectPutaway?.(method === 'DIRECT')}
+          />
         </>
       )}
     </View>

--- a/src/screens/Sortation/styles.ts
+++ b/src/screens/Sortation/styles.ts
@@ -81,6 +81,24 @@ export default StyleSheet.create({
     color: Theme.colors.text,
     fontWeight: 'normal'
   },
+  methodSelector: {
+    marginTop: 4
+  },
+  methodHintRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    marginTop: Theme.spacing.small
+  },
+  methodHintIcon: {
+    marginRight: 6,
+    marginTop: 2
+  },
+  methodHint: {
+    flex: 1,
+    fontSize: 12,
+    color: Theme.colors.secondaryForeground
+  },
   scannerRow: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-566

## Changes
- Added a new `SegmentedControl` component - a generic, presentation-only, theme-driven segmented (tab) control that fills the gap left by `react-native-paper 4.x` not shipping `SegmentedButtons`. Its API takes options (value, label, optional icon), the current value, an onChange handler, and an optional style override. The selected segment shows a white background with a bold label and optional icon.
- In `SortationProductDetails`, the Switch was swapped for this segmented control under a "Putaway Method" heading, with a muted hint line describing the selected method: Sorted reads "Sort to a temporary putaway container - scan a container next." and Direct reads "Put the item away directly to its storage location now." Sorted is the default.

<img width="359" height="111" alt="image" src="https://github.com/user-attachments/assets/5cc2a91f-6d72-4b04-b863-d57417388616" />
