### PR TITLE
OBLS-835 Show destination on the picking screens

### DIFF
--- a/src/screens/Picking/PickingPickLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickLocationScreen.tsx
@@ -91,6 +91,11 @@ export default function PickingPickLocationScreen() {
                 value: currentTask.requisitionNumber || HYPHEN
               },
               {
+                icon: 'map-marker',
+                label: 'Destination',
+                value: currentTask.destination || HYPHEN
+              },
+              {
                 icon: 'package',
                 label: 'Quantity Picked',
                 value: `${currentTask.quantityPicked || 0} / ${currentTask.quantityRequired}`

--- a/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
+++ b/src/screens/Picking/PickingPickOutboundContainerScreen.tsx
@@ -123,6 +123,11 @@ export default function PickingPickOutboundContainerScreen() {
                 value: currentTask.requisitionNumber || HYPHEN
               },
               {
+                icon: 'map-marker',
+                label: 'Destination',
+                value: currentTask.destination || HYPHEN
+              },
+              {
                 icon: 'account',
                 label: 'Assignee',
                 value: currentTask?.assignee

--- a/src/screens/Picking/PickingPickProductScreen.tsx
+++ b/src/screens/Picking/PickingPickProductScreen.tsx
@@ -63,6 +63,11 @@ export default function PickingPickProductScreen() {
                 value: currentTask.requisitionNumber || HYPHEN
               },
               {
+                icon: 'map-marker',
+                label: 'Destination',
+                value: currentTask.destination || HYPHEN
+              },
+              {
                 icon: 'account',
                 label: 'Assignee',
                 value: currentTask?.assignee

--- a/src/screens/Picking/PickingPickQuantityScreen.tsx
+++ b/src/screens/Picking/PickingPickQuantityScreen.tsx
@@ -135,6 +135,11 @@ export default function PickingPickQuantityScreen() {
                   value: currentTask.requisitionNumber || HYPHEN
                 },
                 {
+                  icon: 'map-marker',
+                  label: 'Destination',
+                  value: currentTask.destination || HYPHEN
+                },
+                {
                   icon: 'account',
                   label: 'Assignee',
                   value: currentTask?.assignee

--- a/src/screens/Picking/PickingPickStagingLocationScreen.tsx
+++ b/src/screens/Picking/PickingPickStagingLocationScreen.tsx
@@ -110,6 +110,11 @@ export default function PickingPickStagingLocationScreen() {
                 value: currentTask.requisitionNumber || HYPHEN
               },
               {
+                icon: 'map-marker',
+                label: 'Destination',
+                value: currentTask.destination || HYPHEN
+              },
+              {
                 icon: 'account',
                 label: 'Assignee',
                 value: currentTask?.assignee

--- a/src/types/picking.ts
+++ b/src/types/picking.ts
@@ -35,6 +35,7 @@ export type PickTask = {
   requisitionNumber?: string;
   requisitionStatus?: string;
   requisitionType?: string;
+  destination?: string;
 
   deliveryTypeCode?: DeliveryTypeCode;
 


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-835

Related BE PR: https://github.com/openboxes/openboxes/pull/6011

## Changes
- Add `destination?: string` to the `PickTask` type.
- Render a **Destination** row (map-marker icon) directly under Order Number on all five picking screens: Pick Location, Pick Product, Pick Quantity, Outbound Container, Staging Location.
- Falls back to `HYPHEN` when no destination is present.

<img width="369" height="508" alt="image" src="https://github.com/user-attachments/assets/2e35f49c-1d74-4817-970d-f7d379df8fd5" />
