### PR TITLE
OBLS-837 Polish discrete picking list styling and loading states

### DIFF
--- a/src/redux/sagas/picking.ts
+++ b/src/redux/sagas/picking.ts
@@ -71,18 +71,17 @@ function* getOpenPickTasksAction(action: any) {
     if (!currentLocation) {
       throw new Error('User Location Not Found');
     }
-    yield put(showScreenLoading('Fetching Orders...'));
-    // Call API to get all open pick tasks across every queue type
+    // Call API to get all open pick tasks across every queue type.
+    // No full-screen loading indicator here on purpose: the list screen renders its own
+    // inline skeleton / pull-to-refresh state so the screen never blocks on the fetch.
     // @ts-ignore
     const response = yield call(api.getOpenPickTasksApi, currentLocation.id);
     yield action.callback({ response });
     yield put({ type: GET_OPEN_PICK_TASKS_REQUEST_SUCCESS, payload: response.data });
-    yield put(hideScreenLoading());
   } catch (error) {
     const errorMessage = (error as any)?.message || 'Error Fetching Orders';
     yield put({ type: GET_OPEN_PICK_TASKS_REQUEST_FAIL, payload: errorMessage });
     yield action.callback({ errorMessage });
-    yield put(hideScreenLoading());
   }
 }
 

--- a/src/screens/Picking/DiscretePickingCardSkeleton.tsx
+++ b/src/screens/Picking/DiscretePickingCardSkeleton.tsx
@@ -2,50 +2,36 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { Card } from 'react-native-paper';
 
+import LayoutStyle from '../../assets/styles/LayoutStyle';
 import { ShimmerBlock, SkeletonDivider } from '../../components/ContentSkeleton';
-import Theme from '../../utils/Theme';
 
 export default function DiscretePickingCardSkeleton() {
   return (
-    <View style={styles.wrapper}>
-      <Card style={styles.card}>
-        <Card.Content>
-          <View style={styles.headerRow}>
-            <ShimmerBlock style={styles.orderNumber} />
-            <ShimmerBlock style={styles.statusChip} />
-          </View>
-          <SkeletonDivider />
-          <ShimmerBlock style={styles.destination} />
-          <View style={styles.metaRow}>
-            <ShimmerBlock style={styles.metaChip} />
-            <ShimmerBlock style={styles.metaChip} />
-          </View>
-        </Card.Content>
-      </Card>
-    </View>
+    <Card style={LayoutStyle.listItemContainer}>
+      <Card.Content>
+        <View style={styles.headerRow}>
+          <ShimmerBlock style={styles.orderNumber} />
+          <ShimmerBlock style={styles.statusChip} />
+        </View>
+        <SkeletonDivider />
+        <ShimmerBlock style={styles.destination} />
+        <ShimmerBlock style={styles.destinationType} />
+        <View style={styles.footerRow}>
+          <ShimmerBlock style={styles.metaChip} />
+          <ShimmerBlock style={styles.metaChipWide} />
+        </View>
+      </Card.Content>
+    </Card>
   );
 }
 
 const styles = StyleSheet.create({
-  wrapper: {
-    marginHorizontal: Theme.spacing.medium,
-    marginBottom: Theme.spacing.small - 2
-  },
-  card: {
-    borderRadius: Theme.roundness,
-    backgroundColor: 'white',
-    borderWidth: 1,
-    borderColor: '#ddd'
-  },
-  headerRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: Theme.spacing.small - 2
-  },
-  orderNumber: { width: 140, height: 22, borderRadius: 4 },
-  statusChip: { width: 90, height: 24, borderRadius: Theme.roundness },
-  destination: { width: '70%', height: 16, borderRadius: 4, marginTop: 6 },
-  metaRow: { flexDirection: 'row', marginTop: Theme.spacing.small },
-  metaChip: { width: 90, height: 24, borderRadius: Theme.roundness, marginRight: Theme.spacing.small }
+  headerRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+  footerRow: { flexDirection: 'row', marginTop: 8 },
+  orderNumber: { width: 150, height: 28, borderRadius: 4 },
+  statusChip: { width: 80, height: 28, borderRadius: 4 },
+  destination: { width: '70%', height: 16, borderRadius: 4 },
+  destinationType: { width: '45%', height: 12, borderRadius: 4, marginTop: 6 },
+  metaChip: { width: 110, height: 28, borderRadius: 4, marginRight: 8 },
+  metaChipWide: { width: 90, height: 28, borderRadius: 4 }
 });

--- a/src/screens/Picking/DiscretePickingFilterSkeleton.tsx
+++ b/src/screens/Picking/DiscretePickingFilterSkeleton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import { ShimmerBlock } from '../../components/ContentSkeleton';
+import { DELIVERY_TYPES } from './constants';
+import styles from './discretePickingStyles';
+
+const CHIP_WIDTHS = ['All', ...DELIVERY_TYPES.map((type) => type.label)].map((label) => label.length * 7 + 46);
+
+export default function DiscretePickingFilterSkeleton() {
+  return (
+    <View style={[styles.filterRowContent, styles.filterSkeletonRow]}>
+      {CHIP_WIDTHS.map((width, index) => (
+        <ShimmerBlock key={index} style={[styles.filterChipSkeleton, { width }]} />
+      ))}
+    </View>
+  );
+}

--- a/src/screens/Picking/DiscretePickingListScreen.tsx
+++ b/src/screens/Picking/DiscretePickingListScreen.tsx
@@ -1,7 +1,7 @@
 import { useFocusEffect } from '@react-navigation/native';
 import React, { useCallback, useMemo, useState } from 'react';
 import { FlatList, ScrollView, View } from 'react-native';
-import { Chip } from 'react-native-paper';
+import { Chip, Text } from 'react-native-paper';
 import { useDispatch } from 'react-redux';
 
 import BarcodeSearchHeader from '../../components/BarcodeSearchHeader/BarcodeSearchHeader';
@@ -11,19 +11,20 @@ import { navigate } from '../../NavigationService';
 import { getOpenPickTasksAction } from '../../redux/actions/picking';
 import { DiscretePickingOrder, PickTask } from '../../types/picking';
 import { emptyStateMessage } from '../../utils/emptyStateMessage';
-import { usePickingContext } from './PickingContext';
 import { DELIVERY_TYPES } from './constants';
 import DiscretePickingCardSkeleton from './DiscretePickingCardSkeleton';
-import DiscretePickingOrderCard from './DiscretePickingOrderCard';
+import DiscretePickingFilterSkeleton from './DiscretePickingFilterSkeleton';
 import {
   ALL_QUEUE_TYPES,
   filterOrders,
   groupTasksIntoOrders,
-  QueueTypeFilter,
   queueChipCounts,
+  QueueTypeFilter,
   sortOrders
 } from './discretePickingLib';
+import DiscretePickingOrderCard from './DiscretePickingOrderCard';
 import styles from './discretePickingStyles';
+import { usePickingContext } from './PickingContext';
 
 export default function DiscretePickingListScreen() {
   const dispatch = useDispatch();
@@ -33,20 +34,28 @@ export default function DiscretePickingListScreen() {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [selectedQueueType, setSelectedQueueType] = useState<QueueTypeFilter>(ALL_QUEUE_TYPES);
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false);
+  const [isPullRefreshing, setIsPullRefreshing] = useState<boolean>(false);
   const [hasLoaded, setHasLoaded] = useState<boolean>(false);
 
-  const fetchOrders = useCallback(() => {
-    setIsRefreshing(true);
-    dispatch(
-      getOpenPickTasksAction(({ response, errorMessage }) => {
-        if (!errorMessage && response?.data) {
-          setTasks(response.data);
-        }
-        setIsRefreshing(false);
-        setHasLoaded(true);
-      })
-    );
-  }, [dispatch]);
+  const fetchOrders = useCallback(
+    (fromPull = false) => {
+      setIsRefreshing(true);
+      if (fromPull) {
+        setIsPullRefreshing(true);
+      }
+      dispatch(
+        getOpenPickTasksAction(({ response, errorMessage }) => {
+          if (!errorMessage && response?.data) {
+            setTasks(response.data);
+          }
+          setIsRefreshing(false);
+          setIsPullRefreshing(false);
+          setHasLoaded(true);
+        })
+      );
+    },
+    [dispatch]
+  );
 
   useFocusEffect(
     useCallback(() => {
@@ -54,13 +63,10 @@ export default function DiscretePickingListScreen() {
     }, [fetchOrders])
   );
 
-  // Group tasks into orders and sort by priority once per fetch.
   const sortedOrders = useMemo(() => sortOrders(groupTasksIntoOrders(tasks)), [tasks]);
 
-  // Chip counts are derived from the full (unfiltered) order list.
   const counts = useMemo(() => queueChipCounts(sortedOrders), [sortedOrders]);
 
-  // Real-time filter by search term and selected queue type.
   const visibleOrders = useMemo(
     () => filterOrders(sortedOrders, { search: searchTerm, queueType: selectedQueueType }),
     [sortedOrders, searchTerm, selectedQueueType]
@@ -73,6 +79,8 @@ export default function DiscretePickingListScreen() {
       }
     });
   };
+
+  const isLoadingList = !hasLoaded || isPullRefreshing;
 
   const chips: { value: QueueTypeFilter; label: string; count: number }[] = [
     { value: ALL_QUEUE_TYPES, label: 'All', count: sortedOrders.length },
@@ -87,33 +95,43 @@ export default function DiscretePickingListScreen() {
         placeholder="Search by order, customer, or product"
         resetSearch={() => setSearchTerm('')}
         accessibilityLabel="Search open orders"
+        loading={hasLoaded && isRefreshing}
         onSearchTermSubmit={setSearchTerm}
       />
 
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        style={styles.chipRow}
-        contentContainerStyle={styles.chipRowContent}
-        keyboardShouldPersistTaps="handled"
-      >
-        {chips.map((chip) => {
-          const selected = chip.value === selectedQueueType;
-          return (
-            <Chip
-              key={chip.value}
-              selected={selected}
-              style={[styles.queueChip, selected && styles.queueChipSelected]}
-              textStyle={[styles.queueChipText, selected && styles.queueChipTextSelected]}
-              onPress={() => setSelectedQueueType(chip.value)}
-            >
-              {`${chip.label} (${chip.count})`}
-            </Chip>
-          );
-        })}
-      </ScrollView>
+      <View style={styles.filterBar}>
+        {isLoadingList ? (
+          <DiscretePickingFilterSkeleton />
+        ) : (
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            style={styles.filterRow}
+            contentContainerStyle={styles.filterRowContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            {chips.map((chip) => {
+              const selected = chip.value === selectedQueueType;
+              const textStyle = [styles.filterChipText, selected && styles.filterChipTextSelected];
+              return (
+                <Chip
+                  key={chip.value}
+                  accessibilityLabel={`${chip.label}, ${chip.count} orders`}
+                  accessibilityState={{ selected }}
+                  style={[styles.filterChip, selected && styles.filterChipSelected]}
+                  onPress={() => setSelectedQueueType(chip.value)}
+                >
+                  <Text style={textStyle}>
+                    {chip.label} <Text style={[textStyle, styles.fontBold]}>({chip.count})</Text>
+                  </Text>
+                </Chip>
+              );
+            })}
+          </ScrollView>
+        )}
+      </View>
 
-      {!hasLoaded ? (
+      {isLoadingList ? (
         <ListLoadingSkeleton visible count={5} CardComponent={DiscretePickingCardSkeleton} />
       ) : (
         <FlatList
@@ -123,15 +141,16 @@ export default function DiscretePickingListScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
           contentContainerStyle={styles.listContent}
-          ItemSeparatorComponent={() => <View style={styles.itemSeparator} />}
-          refreshing={isRefreshing}
+          // The skeleton above owns the pull-to-refresh loading state, so the spinner
+          // only needs to retract once the gesture hands off to it.
+          refreshing={false}
           ListEmptyComponent={
             <EmptyView
               title="Orders"
               description={emptyStateMessage('orders', searchTerm, 'No open orders ready for picking')}
             />
           }
-          onRefresh={fetchOrders}
+          onRefresh={() => fetchOrders(true)}
         />
       )}
     </View>

--- a/src/screens/Picking/DiscretePickingOrderCard.tsx
+++ b/src/screens/Picking/DiscretePickingOrderCard.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import { TouchableOpacity, View } from 'react-native';
-import { Caption, Card, Chip, Divider, Text } from 'react-native-paper';
+import { View } from 'react-native';
+import { Caption, Card, Chip, Divider, Subheading, Text } from 'react-native-paper';
 
+import { LayoutStyle } from '../../assets/styles';
 import { HYPHEN } from '../../constants';
 import { DiscretePickingOrder } from '../../types/picking';
+import Theme from '../../utils/Theme';
 import { DELIVERY_TYPES } from './constants';
 import styles from './discretePickingStyles';
 
@@ -18,47 +20,63 @@ type Props = {
 };
 
 export default function DiscretePickingOrderCard({ order, onPress }: Props) {
-  const queueLabel = order.deliveryTypeCode
+  const deliveryTypeLabel = order.deliveryTypeCode
     ? DELIVERY_TYPE_LABELS[order.deliveryTypeCode] ?? order.deliveryTypeCode
     : null;
-  const lineLabel = `${order.taskCount} ${order.taskCount === 1 ? 'line' : 'lines'}`;
+  const lineCountLabel = order.taskCount === 1 ? 'Line' : 'Lines';
 
   return (
-    <TouchableOpacity activeOpacity={0.85} style={styles.cardTouchable} onPress={() => onPress(order)}>
-      <Card style={styles.card}>
-        <Card.Content>
-          <View style={styles.cardHeader}>
-            <Text style={styles.orderNumber} numberOfLines={1}>
-              {order.requisitionNumber ?? HYPHEN}
-            </Text>
-            <Chip
-              icon={order.inProgress ? 'progress-clock' : 'check-circle-outline'}
-              style={styles.metaChip}
-              textStyle={styles.metaChipText}
+    <Card style={LayoutStyle.listItemContainer} onPress={() => onPress(order)}>
+      <Card.Content>
+        <View style={styles.headerRow}>
+          <Chip icon="identifier" style={[styles.chipDefault, styles.orderNumberChip]}>
+            <Text style={[styles.orderNumberText, styles.fontBold]}>{order.requisitionNumber ?? HYPHEN}</Text>
+          </Chip>
+          <Chip
+            icon={order.inProgress ? 'progress-clock' : 'check-circle-outline'}
+            selectedColor={order.inProgress ? Theme.colors.infoForeground : Theme.colors.successForeground}
+            style={[
+              styles.chipDefault,
+              styles.statusChip,
+              order.inProgress ? styles.statusChipInProgress : styles.statusChipReady
+            ]}
+          >
+            <Text
+              style={[
+                styles.chipText,
+                styles.fontBold,
+                order.inProgress ? styles.statusChipTextInProgress : styles.statusChipTextReady
+              ]}
             >
               {order.inProgress ? 'In progress' : 'Ready'}
+            </Text>
+          </Chip>
+        </View>
+
+        <Divider style={styles.contentDivider} />
+
+        <Subheading style={styles.destination} numberOfLines={2}>
+          {order.destination ?? HYPHEN}
+        </Subheading>
+        {order.destinationLocationType ? (
+          <Caption style={styles.destinationType}>{order.destinationLocationType}</Caption>
+        ) : null}
+
+        <View style={styles.additionalInfoRow}>
+          {deliveryTypeLabel ? (
+            <Chip icon="tag-outline" style={styles.chipDefault}>
+              <Text style={styles.chipText}>
+                Type: <Text style={[styles.chipText, styles.fontBold]}>{deliveryTypeLabel}</Text>
+              </Text>
             </Chip>
-          </View>
-
-          <Divider style={styles.cardDivider} />
-
-          <Text style={styles.destination} numberOfLines={2}>
-            {order.destination ?? HYPHEN}
-          </Text>
-          {order.destinationLocationType ? <Caption>{order.destinationLocationType}</Caption> : null}
-
-          <View style={styles.metaRow}>
-            {queueLabel ? (
-              <Chip icon="tag-outline" style={styles.metaChip} textStyle={styles.metaChipText}>
-                {queueLabel}
-              </Chip>
-            ) : null}
-            <Chip icon="package-variant-closed" style={styles.metaChip} textStyle={styles.metaChipText}>
-              {lineLabel}
-            </Chip>
-          </View>
-        </Card.Content>
-      </Card>
-    </TouchableOpacity>
+          ) : null}
+          <Chip icon="package-variant-closed" style={styles.chipDefault}>
+            <Text style={styles.chipText}>
+              {lineCountLabel}: <Text style={[styles.chipText, styles.fontBold]}>{order.taskCount}</Text>
+            </Text>
+          </Chip>
+        </View>
+      </Card.Content>
+    </Card>
   );
 }

--- a/src/screens/Picking/discretePickingStyles.ts
+++ b/src/screens/Picking/discretePickingStyles.ts
@@ -5,84 +5,114 @@ import Theme from '../../utils/Theme';
 export default StyleSheet.create({
   screenContainer: {
     flex: 1,
-    backgroundColor: '#f9f9f9'
+    backgroundColor: Theme.colors.background
   },
-  chipRow: {
+
+  filterBar: {
+    backgroundColor: 'white'
+  },
+  filterRow: {
+    flexGrow: 0,
+    flexShrink: 0
+  },
+  filterRowContent: {
+    alignItems: 'center',
     paddingHorizontal: Theme.spacing.medium,
     paddingVertical: Theme.spacing.small
   },
-  chipRowContent: {
+  filterChip: {
+    height: 32,
+    justifyContent: 'center',
     alignItems: 'center',
-    paddingRight: Theme.spacing.medium
-  },
-  queueChip: {
+    borderRadius: 12,
     marginRight: Theme.spacing.small,
-    backgroundColor: '#fff',
-    borderColor: '#ddd',
-    borderWidth: 1
-  },
-  queueChipSelected: {
-    backgroundColor: Theme.colors.primary
-  },
-  queueChipText: {
-    fontSize: 12,
-    color: Theme.colors.primary
-  },
-  queueChipTextSelected: {
-    color: '#fff'
-  },
-  listContent: {
-    paddingHorizontal: Theme.spacing.medium,
-    paddingBottom: Theme.spacing.large
-  },
-  itemSeparator: {
-    height: Theme.spacing.small - 2
-  },
-
-  cardTouchable: {
-    borderRadius: Theme.roundness
-  },
-  card: {
-    borderRadius: Theme.roundness,
     backgroundColor: 'white',
     borderWidth: 1,
-    borderColor: '#ddd'
+    borderColor: '#ced4da'
   },
-  cardHeader: {
+  filterChipSelected: {
+    backgroundColor: Theme.colors.primary,
+    borderColor: Theme.colors.primary
+  },
+  filterChipText: {
+    fontSize: 12,
+    color: Theme.colors.secondaryForeground
+  },
+  filterChipTextSelected: {
+    color: 'white'
+  },
+  filterSkeletonRow: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: Theme.spacing.small - 2
+    overflow: 'hidden'
   },
-  orderNumber: {
-    fontSize: 16,
-    fontWeight: '600',
-    flexShrink: 1,
+  filterChipSkeleton: {
+    height: 32,
+    borderRadius: 12,
     marginRight: Theme.spacing.small
   },
-  cardDivider: {
-    marginVertical: Theme.spacing.small / 2
+
+  listContent: {
+    paddingBottom: Theme.spacing.large
+  },
+
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  // Shrinks so a long order number truncates instead of pushing the status chip off-card.
+  orderNumberChip: {
+    flexShrink: 1
+  },
+  orderNumberText: {
+    fontSize: 14,
+    color: Theme.colors.text
+  },
+  contentDivider: {
+    marginVertical: 8
   },
   destination: {
-    fontSize: 14,
-    color: '#333',
-    marginTop: Theme.spacing.small / 2
+    fontWeight: 'bold',
+    color: Theme.colors.text
   },
-  metaRow: {
+  destinationType: {
+    marginTop: -2,
+    color: Theme.colors.secondaryForeground
+  },
+  additionalInfoRow: {
     flexDirection: 'row',
+    marginTop: 8,
     alignItems: 'center',
-    flexWrap: 'wrap',
-    marginTop: Theme.spacing.small
+    flexWrap: 'wrap'
   },
-  metaChip: {
-    height: 24,
-    justifyContent: 'center',
-    borderRadius: Theme.roundness,
-    marginRight: Theme.spacing.small,
-    marginTop: Theme.spacing.small / 2,
-    backgroundColor: Theme.colors.secondaryBackground
+  chipDefault: {
+    height: 28,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    borderRadius: 4,
+    marginRight: 8,
+    backgroundColor: Theme.colors.background
   },
-  metaChipText: {
-    fontSize: 12
+  chipText: {
+    fontSize: 12,
+    color: Theme.colors.text
+  },
+  fontBold: {
+    fontWeight: 'bold'
+  },
+  statusChip: {
+    marginRight: 0
+  },
+  statusChipReady: {
+    backgroundColor: Theme.colors.successBackground
+  },
+  statusChipTextReady: {
+    color: Theme.colors.successForeground
+  },
+  statusChipInProgress: {
+    backgroundColor: Theme.colors.infoBackground
+  },
+  statusChipTextInProgress: {
+    color: Theme.colors.infoForeground
   }
 });


### PR DESCRIPTION
https://openboxes.atlassian.net/browse/OBLS-837

Bring the Discrete Picking order list in line with the card and chip conventions used elsewhere in the app, and replace the blocking fetch indicator with inline loading states.

- drop the full-screen "Fetching Orders..." indicator from getOpenPickTasksAction; the screen owns its loading state
- skeleton the order cards and the queue-type filter row on first load and on pull-to-refresh; a refetch on focus only spins the search box
- keep the chip row at content height so it is no longer clipped top and bottom, and remove the selected check
- rebuild on LayoutStyle.listItemContainer like Products / Search Inventory, with ProductDetails-style chips (label + bold value) for the order number, type and line count
- tint icon and label from the theme's success / info tokens
- stop overriding Paper's text metrics, which was breaking vertical centering

<img width="368" height="585" alt="image" src="https://github.com/user-attachments/assets/1c38e68e-9f95-49aa-a7c2-a1c9f9a681ed" />
<img width="368" height="585" alt="image" src="https://github.com/user-attachments/assets/a1db24d9-5231-49f8-9566-dfd2a092c022" />
<img width="368" height="585" alt="image" src="https://github.com/user-attachments/assets/ad423ff1-0f53-4ae5-8578-13df351eab43" />
