### PR TITLE
Fix duplicate scans from concurrent scan listeners

### DIFF
--- a/src/hooks/useScanListener.ts
+++ b/src/hooks/useScanListener.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { DeviceEventEmitter, Platform } from 'react-native';
+import { DeviceEventEmitter, EmitterSubscription, Platform } from 'react-native';
 import DataWedgeIntents from 'react-native-datawedge-intents';
 
 import {
@@ -17,7 +17,21 @@ export type ScanResult = {
   labelType?: string;
 };
 
+type ScanCallback = (result: ScanResult) => void;
+
 let profileConfigured = false;
+
+// The scanner is owned by a single listener at a time. Enabled consumers are
+// tracked as a stack and only the most recently enabled one (top of stack)
+// receives scans, behind one shared DeviceEventEmitter subscription.
+//
+// A single hardware scan produces exactly one intent broadcast, which the
+// emitter dispatches to every registered listener. Without single-owner
+// delivery, when two ScannerInputs are momentarily mounted together — e.g. a
+// screen input and a modal dialog input during a dialog open/close transition —
+// both would handle the same scan and the value would be applied twice.
+const scanCallbacks: ScanCallback[] = [];
+let sharedSubscription: EmitterSubscription | null = null;
 
 function sendDataWedgeCommand(extraName: string, extraValue: unknown): void {
   DataWedgeIntents.sendBroadcastWithExtras({
@@ -45,7 +59,35 @@ function extractScan(intent: Record<string, any>): ScanResult | null {
   return { data: String(data).trim(), labelType: labelType ? String(labelType) : undefined };
 }
 
-export function useScanListener(onScan: (result: ScanResult) => void, enabled = true): void {
+function ensureSubscribed(): void {
+  if (sharedSubscription) {
+    return;
+  }
+  configureProfileOnce();
+  DataWedgeIntents.registerBroadcastReceiver({
+    filterActions: FILTER_ACTIONS,
+    filterCategories: FILTER_CATEGORY
+  });
+  sharedSubscription = DeviceEventEmitter.addListener(LISTENER.BROADCAST_INTENT, (intent: Record<string, any>) => {
+    const activeCallback = scanCallbacks[scanCallbacks.length - 1];
+    if (!activeCallback) {
+      return;
+    }
+    const result = extractScan(intent);
+    if (result) {
+      activeCallback(result);
+    }
+  });
+}
+
+function teardownIfIdle(): void {
+  if (scanCallbacks.length === 0 && sharedSubscription) {
+    sharedSubscription.remove();
+    sharedSubscription = null;
+  }
+}
+
+export function useScanListener(onScan: ScanCallback, enabled = true): void {
   const onScanRef = useRef(onScan);
   onScanRef.current = onScan;
 
@@ -54,20 +96,16 @@ export function useScanListener(onScan: (result: ScanResult) => void, enabled = 
       return;
     }
 
-    configureProfileOnce();
-    DataWedgeIntents.registerBroadcastReceiver({
-      filterActions: FILTER_ACTIONS,
-      filterCategories: FILTER_CATEGORY
-    });
+    const callback: ScanCallback = (result) => onScanRef.current(result);
+    scanCallbacks.push(callback);
+    ensureSubscribed();
 
-    const handleIntent = (intent: Record<string, any>) => {
-      const result = extractScan(intent);
-      if (result) {
-        onScanRef.current(result);
+    return () => {
+      const index = scanCallbacks.indexOf(callback);
+      if (index !== -1) {
+        scanCallbacks.splice(index, 1);
       }
+      teardownIfIdle();
     };
-
-    const subscription = DeviceEventEmitter.addListener(LISTENER.BROADCAST_INTENT, handleIntent);
-    return () => subscription.remove();
   }, [enabled]);
 }


### PR DESCRIPTION
Follow-up to #423 (OBLS-822).

## Problem
A single hardware scan produces exactly one DataWedge intent broadcast, which `DeviceEventEmitter` dispatches to **every** registered listener. `useScanListener` adds one listener per enabled consumer, so whenever two `ScannerInput`s are mounted at the same time the same scan is handled twice and the value is applied twice.

This happens on screens that pair a screen-level `ScannerInput` with a modal dialog that contains its own `ScannerInput` (e.g. `SortationContainerScreen` + `ContainerMismatchDialog`, `PutawayLocationScanScreen`, `PutawayQuantityScreen`). Each screen disables one input while the other is active (`isEnabled={!isDialogVisible ...}`), but during the dialog open/close transition both inputs can be subscribed for a moment, and a scan in that window is delivered to both listeners.

This is **not** native-receiver stacking: `react-native-datawedge-intents` reuses a single `genericReceiver` and unregisters it before re-registering, so there is only ever one native receiver and one emit per scan. The duplication is purely on the JS listener side.

## Change
- Route all scans through a **single shared** `DeviceEventEmitter` subscription.
- Track enabled consumers as a stack and deliver each scan only to the **most recently enabled** one — the scanner is owned by one listener at a time. This is robust to two `ScannerInput`s being briefly subscribed together: only the active (top-of-stack) one handles the scan.

This preserves the existing `enabled` gating on `useScanListener` (`ScannerInput` still passes `shouldBeFocused`) and matches the codebase invariant of one scanner input per screen; `useBarcodeScanned` is unchanged.

## How to test (no Zebra required)
Open the inbound sortation flow (Sortation → scan product → container screen), then from a connected device/emulator:

`adb shell am broadcast -a com.openboxes.android.ACTION --es com.symbol.datawedge.data_string "0123456789" --es com.symbol.datawedge.label_type "LABEL-TYPE-CODE128"`

The value should be applied **once**. Also exercise the container-mismatch dialog (scan a wrong container to open it, then scan again inside the dialog) and confirm no double entry/submit across the dialog transition.

## Not covered here
DataWedge **Keystroke** output is still enabled alongside Intent output, so a scan is also typed into the focused field. That's a separate potential duplicate source (would show as doubled/appended text or a double submit, including on single-input screens with no dialog). Left out of this PR; can be addressed separately if it turns out to be a real symptom in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)