### PR TITLE
OBLS-822 Disable DataWedge keystroke output for barcode inputs

### DIFF
--- a/src/hooks/constant.ts
+++ b/src/hooks/constant.ts
@@ -64,3 +64,21 @@ export const PROFILE_CONFIG2 = {
     }
   }
 };
+
+// Keystroke output is a profile-wide DataWedge setting, so it cannot be scoped to
+// a single field. It is toggled at runtime: disabled while a barcode input owns
+// the scanner (so a scan arrives only via the intent broadcast and is not also
+// typed into the focused field as keystrokes), and re-enabled otherwise so plain
+// inputs elsewhere can still be populated by scanning.
+export const getKeystrokeOutputConfig = (enabled: boolean) => ({
+  PROFILE_NAME: 'OPENBOXES',
+  PROFILE_ENABLED: 'true',
+  CONFIG_MODE: 'UPDATE',
+  PLUGIN_CONFIG: {
+    PLUGIN_NAME: 'KEYSTROKE',
+    RESET_CONFIG: 'true',
+    PARAM_LIST: {
+      keystroke_output_enabled: enabled ? 'true' : 'false'
+    }
+  }
+});

--- a/src/hooks/useScanListener.ts
+++ b/src/hooks/useScanListener.ts
@@ -6,6 +6,7 @@ import {
   ACTION,
   FILTER_ACTIONS,
   FILTER_CATEGORY,
+  getKeystrokeOutputConfig,
   LISTENER,
   PROFILE,
   PROFILE_CONFIG,
@@ -18,6 +19,10 @@ export type ScanResult = {
 };
 
 let profileConfigured = false;
+
+// Number of barcode inputs currently listening for scans. Keystroke output is
+// muted while this is > 0 (see below).
+let activeConsumerCount = 0;
 
 function sendDataWedgeCommand(extraName: string, extraValue: unknown): void {
   DataWedgeIntents.sendBroadcastWithExtras({
@@ -34,6 +39,10 @@ function configureProfileOnce(): void {
   sendDataWedgeCommand(PROFILE.CREATE_PROFILE, PROFILE.NAME);
   sendDataWedgeCommand(PROFILE.SET_CONFIG_PROFILE, PROFILE_CONFIG);
   sendDataWedgeCommand(PROFILE.SET_CONFIG_PROFILE, PROFILE_CONFIG2);
+}
+
+function setKeystrokeOutput(enabled: boolean): void {
+  sendDataWedgeCommand(PROFILE.SET_CONFIG_PROFILE, getKeystrokeOutputConfig(enabled));
 }
 
 function extractScan(intent: Record<string, any>): ScanResult | null {
@@ -60,6 +69,16 @@ export function useScanListener(onScan: (result: ScanResult) => void, enabled = 
       filterCategories: FILTER_CATEGORY
     });
 
+    // A barcode input is now listening via the intent broadcast. While any is
+    // active, mute DataWedge keystroke output so the scan is not also typed into
+    // the focused field (which would duplicate/append the value). Reference
+    // counted so overlapping inputs (e.g. a screen input and a modal input) keep
+    // it muted until the last one goes away, then restore it for plain inputs.
+    activeConsumerCount += 1;
+    if (activeConsumerCount === 1) {
+      setKeystrokeOutput(false);
+    }
+
     const handleIntent = (intent: Record<string, any>) => {
       const result = extractScan(intent);
       if (result) {
@@ -68,6 +87,12 @@ export function useScanListener(onScan: (result: ScanResult) => void, enabled = 
     };
 
     const subscription = DeviceEventEmitter.addListener(LISTENER.BROADCAST_INTENT, handleIntent);
-    return () => subscription.remove();
+    return () => {
+      subscription.remove();
+      activeConsumerCount -= 1;
+      if (activeConsumerCount === 0) {
+        setKeystrokeOutput(true);
+      }
+    };
   }, [enabled]);
 }


### PR DESCRIPTION
Fixes the duplicate/doubled barcode value on scan (OBLS-822), a regression from the intent-based scan capture in #423.

## Problem
A scan was delivered through **two** DataWedge channels at once:
- **Intent output** → `useScanListener` → `onChange(value)` (the path added in #423), and
- **Keystroke output** → the barcode typed into the focused field as key events.

Because keystroke typing is additive and the intent `onChange` replaces, the two concatenate: the scanned string is appended to itself. Confirmed on **TC52** and **TC53e** — a scan of `4354210` submitted as `43542104354210`, and `ABP N60C IQ3980` as `ABP N60C IQ3980ABP N60C IQ3980`.

It did **not** reproduce on a TC20, which is the tell: the app never explicitly controlled keystroke output — `configureProfileOnce()` only sets the BARCODE and INTENT plugins (`CONFIG_MODE: 'UPDATE'`), leaving the Keystroke plugin at each device's default. So whether both channels fire (and whether they concatenate, which also depends on intent-vs-keystroke delivery timing) was left to per-device DataWedge state.

## Fix
Explicitly control keystroke output so behavior is deterministic across devices. Keystroke output is a **profile-wide** setting (the OPENBOXES profile is associated with every activity) and can't be scoped to a single field, so it's toggled at runtime:

- **Muted** while any barcode input (`useScanListener` consumer) is active → the scan arrives only via the intent broadcast, never also typed into the field.
- **Restored** when no barcode input is active → plain inputs elsewhere can still be populated by scanning.

The active-consumer count is reference-counted so overlapping inputs (e.g. a screen input and a modal input during a dialog transition) keep it muted until the last one unmounts.

Manual keyboard entry is unaffected — `keystroke_output_enabled` controls only the scanner's keystroke emulation, not the soft keyboard.

## Scope
- `src/hooks/constant.ts` — `getKeystrokeOutputConfig(enabled)` (KEYSTROKE plugin config).
- `src/hooks/useScanListener.ts` — reference-counted keystroke mute/restore around the existing intent subscription. No change to the subscription model otherwise.

## Testing
Built locally (`./gradlew assembleRelease`) and sideloaded to a TC52: the doubling is gone — scans on the Inbound Sortation screen now apply the value once. Manual typing into scan fields still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018esj4qV5h4teD7M6WfHahM)_